### PR TITLE
docs: update BETA.md with actual Google Form link

### DIFF
--- a/BETA.md
+++ b/BETA.md
@@ -34,7 +34,7 @@ We're seeking **5-10 teams** that:
 
 ## 📝 Application Process
 
-1. **Apply** - Fill out our [Early Access Form](https://forms.gle/YOUR_FORM_ID) (2 minutes)
+1. **Apply** - Fill out our [Early Access Form](https://forms.gle/dmeKzseAbhPA6KLq8) (2 minutes)
 2. **Review** - We'll review applications within 24-48 hours
 3. **Onboarding** - You'll receive:
    - Setup instructions and documentation
@@ -150,7 +150,7 @@ Have questions before applying?
 
 ## 🚀 Ready to Join?
 
-**[📝 Apply Now - Early Access Form →](https://forms.gle/YOUR_FORM_ID)**
+**[📝 Apply Now - Early Access Form →](https://forms.gle/dmeKzseAbhPA6KLq8)**
 
 ---
 


### PR DESCRIPTION
Complete the Early Access Beta setup by updating the remaining placeholder links in BETA.md with the actual Google Form URL.

## Changes

- Updated 2 instances of `YOUR_FORM_ID` in BETA.md
- Both links now point to: https://forms.gle/dmeKzseAbhPA6KLq8

## Context

README.md was already updated in a previous commit. This PR completes the setup by updating BETA.md.

Now all Early Access application links are live and functional! 🚀