### PR TITLE
fix: TypeScript compilation errors in dashboard controller

### DIFF
--- a/backend/src/controllers/dashboard.controller.ts
+++ b/backend/src/controllers/dashboard.controller.ts
@@ -332,8 +332,8 @@ export class DashboardController {
           occurredAt: {
             gte: startDate,
           },
-          severity: {
-            not: null,
+          NOT: {
+            severity: null,
           },
         },
         _count: {
@@ -341,7 +341,10 @@ export class DashboardController {
         },
       });
 
-      const total = severityCounts.reduce((sum, item) => sum + (item._count?.severity || 0), 0);
+      const total = severityCounts.reduce((sum, item) => {
+        const count = typeof item._count === 'object' && item._count.severity ? item._count.severity : 0;
+        return sum + count;
+      }, 0);
 
       const categoryColors: Record<FailureCategory, string> = {
         bug_critical: '#ef4444',
@@ -362,7 +365,7 @@ export class DashboardController {
 
       return severityCounts.map(item => {
         const category = item.severity ? categoryMap[item.severity] || 'unknown' : 'unknown';
-        const count = item._count?.severity || 0;
+        const count = typeof item._count === 'object' && item._count.severity ? item._count.severity : 0;
         return {
           category,
           count,


### PR DESCRIPTION
## Final Fix for Clean Backend Startup

**Problem**: Backend crashes with TypeScript compilation errors

### Errors Fixed
1. **TS2322**: Type 'null' is not assignable to FailureSeverity filter
   - Changed from `severity: { not: null }` to `NOT: { severity: null }`
   - Uses correct Prisma filter syntax

2. **TS2339**: Property 'severity' does not exist on union type
   - Added type guard: `typeof item._count === 'object' && item._count.severity`
   - Safely handles Prisma groupBy _count union type

### Impact
- Backend compiles successfully
- No TypeScript errors
- Dashboard API works correctly

## Testing
```bash
git pull origin claude/setup-automation-ready-HnZcE
npm run dev  # Backend starts clean!
```

This completes the production-ready backend setup!