### PR TITLE
Fix SQLite enum support for demo mode (dev:simple)

### DIFF
--- a/backend/prisma/schema.dev.prisma
+++ b/backend/prisma/schema.dev.prisma
@@ -1,5 +1,6 @@
 // SQLite Development Schema for Demo Mode
 // This is a simplified version using SQLite instead of PostgreSQL
+// Note: SQLite doesn't support enums, so we use String with validation
 
 generator client {
   provider = "prisma-client-js"
@@ -11,32 +12,12 @@ datasource db {
   url      = "file:./dev.db"
 }
 
-enum UserRole {
-  ADMIN
-  USER
-}
-
-enum FailureStatus {
-  NEW
-  INVESTIGATING
-  DOCUMENTED
-  RESOLVED
-  RECURRING
-}
-
-enum FailureSeverity {
-  CRITICAL
-  HIGH
-  MEDIUM
-  LOW
-}
-
 model User {
   id        String   @id @default(uuid())
   email     String   @unique
   firstName String?
   lastName  String?
-  role      UserRole @default(USER)
+  role      String   @default("USER") // ADMIN | USER
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -82,7 +63,7 @@ model FailureArchive {
   workaround            String?
 
   // Resolution tracking
-  status                FailureStatus    @default(NEW)
+  status                String           @default("NEW") // NEW | INVESTIGATING | DOCUMENTED | RESOLVED | RECURRING
   resolvedAt            DateTime?
   resolvedBy            String?
   timeToResolve         Int?
@@ -100,7 +81,7 @@ model FailureArchive {
   recurrencePattern     String?
 
   // Metadata
-  severity              FailureSeverity  @default(MEDIUM)
+  severity              String           @default("MEDIUM") // CRITICAL | HIGH | MEDIUM | LOW
   isKnownIssue          Boolean          @default(false)
 
   // Timestamps


### PR DESCRIPTION
## Summary
- Converts all enum types to String fields in schema.dev.prisma
- Fixes Prisma P1012 error: "The current connector does not support enums"
- Enables dev:simple demo mode to work with SQLite database

## Changes
- Removed `enum UserRole`, `enum FailureStatus`, `enum FailureSeverity`
- Changed User.role from `UserRole` to `String` with comment `// ADMIN | USER`
- Changed FailureArchive.status from `FailureStatus` to `String` with comment for valid values
- Changed FailureArchive.severity from `FailureSeverity` to `String` with comment for valid values

## Why
SQLite does not support enum types like PostgreSQL does. The demo mode (dev:simple) uses SQLite for instant setup without Docker, so we need to use String fields instead.

## Test Plan
- [x] Schema.dev.prisma validation passes
- [ ] Run `npm run dev:simple` successfully
- [ ] Verify 150+ mock failures are seeded
- [ ] Check dashboard shows all categories correctly
- [ ] Confirm no TypeScript compilation errors