### PR TITLE
Fix seed script TypeScript compilation errors

### DIFF
--- a/backend/prisma/seed.dev.ts
+++ b/backend/prisma/seed.dev.ts
@@ -3,7 +3,7 @@
  * Creates realistic test failures and AI analysis data for dashboard demo
  */
 
-import { PrismaClient } from '.prisma/client-dev';
+import { PrismaClient } from '../node_modules/.prisma/client-dev';
 
 const prisma = new PrismaClient();
 
@@ -197,8 +197,8 @@ async function seedDevelopmentData() {
           solution: template.solution,
           preventionSteps: template.preventionSteps,
           workaround: i % 3 === 0 ? 'Restart the service and retry' : null,
-          status: ['NEW', 'INVESTIGATING', 'DOCUMENTED', 'RESOLVED'][Math.floor(Math.random() * 4)] as any,
-          severity: config.severity as any,
+          status: ['NEW', 'INVESTIGATING', 'DOCUMENTED', 'RESOLVED'][Math.floor(Math.random() * 4)],
+          severity: config.severity,
           isRecurring: Math.random() > 0.7,
           occurrenceCount: Math.floor(Math.random() * 10) + 1,
           isKnownIssue: Math.random() > 0.8,


### PR DESCRIPTION
## Summary
- Fixes TypeScript import path for SQLite Prisma client
- Removes unnecessary type casts
- Enables dev:simple seeding to work correctly

## Changes
- Changed import from `.prisma/client-dev` to `../node_modules/.prisma/client-dev`
- Removed `as any` casts on status and severity fields (String types now match)

## Why
TypeScript could not resolve the `.prisma/client-dev` import path when running ts-node, causing "type never" errors. Using relative path fixes resolution.

## Test
After merging, run:
```bash
git pull origin main
npm run dev:simple
```

Should complete without TypeScript errors and seed 150+ failures.