### PR TITLE
Fix: Auto-install all dependencies with postinstall hook

### DIFF
--- a/DEV_MODE.md
+++ b/DEV_MODE.md
@@ -23,10 +23,15 @@ npm run dev:simple
 # Backend: http://localhost:4000
 ```
 
-**First time setup**:
+**First time setup** (fresh clone):
+```bash
+npm install  # Installs ALL dependencies (root, backend, frontend)
+npm run dev:simple
+```
+
+**If you already have node_modules**:
 ```bash
 git pull origin main
-npm install  # If you haven't already
 npm run dev:simple
 ```
 

--- a/QUICKSTART_DEMO.md
+++ b/QUICKSTART_DEMO.md
@@ -1,0 +1,59 @@
+# 🚀 Quick Start - Demo Mode (No Docker!)
+
+**Want to see TestOps Companion in action? This takes 2 minutes.**
+
+## Fresh Install (First Time)
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/rayalon1984/testops-companion.git
+cd testops-companion
+
+# 2. Install dependencies (this installs EVERYTHING automatically)
+npm install
+
+# 3. Start demo mode
+npm run dev:simple
+```
+
+**That's it!** Open http://localhost:5173 in your browser.
+
+## What You Get
+
+- 150+ realistic test failures with AI analysis
+- Beautiful dashboard with charts and metrics
+- No Docker needed
+- No database setup needed
+- Perfect for demos and screenshots
+
+## Already Have the Repo?
+
+```bash
+git pull origin main
+npm install  # Make sure all dependencies are up to date
+npm run dev:simple
+```
+
+## Troubleshooting
+
+**"command not found" errors?**
+```bash
+# Run npm install again - it auto-installs backend and frontend
+npm install
+npm run dev:simple
+```
+
+**Port already in use?**
+```bash
+# Kill processes on ports 4000 and 5173
+lsof -ti:4000 | xargs kill -9
+lsof -ti:5173 | xargs kill -9
+npm run dev:simple
+```
+
+**Need production mode with Docker?**
+See [DEV_MODE.md](./DEV_MODE.md) for `npm run dev` with PostgreSQL/Redis/Weaviate.
+
+---
+
+**Next Steps**: Check out [DEV_MODE.md](./DEV_MODE.md) for full documentation on both demo and production modes.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A comprehensive test operations companion for managing test pipelines and results",
   "main": "index.js",
   "scripts": {
+    "postinstall": "npm run install:backend && npm run install:frontend",
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:simple": "concurrently \"npm run dev:simple:backend\" \"npm run dev:frontend\"",
     "dev:simple:backend": "cd backend && npm run dev:simple",


### PR DESCRIPTION
## Summary
- Adds postinstall hook to automatically install backend and frontend dependencies
- Creates QUICKSTART_DEMO.md for foolproof setup instructions
- Updates DEV_MODE.md with clear first-time setup steps

## Problem
Fresh clones required manual `npm install` in backend/ and frontend/ directories, causing "command not found" errors.

## Solution
Added `postinstall` script that automatically runs:
- `npm run install:backend`
- `npm run install:frontend`

Now a single `npm install` sets up everything.

## Test
After merging:
```bash
rm -rf testops-companion  # Fresh start
git clone https://github.com/rayalon1984/testops-companion.git
cd testops-companion
npm install  # Auto-installs EVERYTHING
npm run dev:simple  # Works immediately
```

Should open on http://localhost:5173 with 150+ seeded failures.