### PR TITLE
refactor: Phase C — consolidate AI config into AIConfigManager

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -89,18 +89,52 @@ ENABLE_2FA=false
 PASSWORD_RESET_TOKEN_EXPIRY=1h
 ALLOWED_DOMAINS=*
 
-# AI Configuration (Optional - v2.5.3+)
+# AI Configuration (Optional - v2.9.0+)
+# All AI config is managed centrally by AIConfigManager (config.ts).
+# Env vars override YAML file config (config/ai.yml).
+
+# Core
 AI_ENABLED=false
 AI_PROVIDER=anthropic
 AI_MODEL=claude-opus-4-6
+
+# Provider API Keys (set the one matching AI_PROVIDER)
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+# OPENAI_ORG_ID=
 GOOGLE_API_KEY=
-AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_KEY=
+AZURE_OPENAI_ENDPOINT=
 AZURE_DEPLOYMENT_NAME=
 OPENROUTER_API_KEY=
-WEAVIATE_URL=http://localhost:8081
+# OPENROUTER_SITE_URL=https://testops-companion.dev
+# OPENROUTER_APP_NAME=TestOps Companion
+
+# Provider Settings
+# AI_MAX_TOKENS=4096
+# AI_TEMPERATURE=1.0
+# AI_TIMEOUT_MS=60000
+
+# Feature Flags
 AI_FEATURE_RCA_MATCHING=true
 AI_FEATURE_CATEGORIZATION=true
 AI_FEATURE_LOG_SUMMARY=true
+# AI_FEATURE_NL_QUERIES=false
+# AI_FEATURE_TICKET_GENERATION=true
+
+# Vector Database
+WEAVIATE_URL=http://localhost:8081
+# WEAVIATE_API_KEY=
+
+# Cost Management
+# AI_MONTHLY_BUDGET_USD=100
+# AI_ALERT_THRESHOLD_PERCENT=80
+# AI_ALERT_EMAIL=
+
+# Cache
+# AI_CACHE_ENABLED=true
+# AI_CACHE_TTL_SECONDS=604800
+
+# Rate Limiting
+# AI_RATE_LIMIT_PER_MINUTE=100
+# AI_RATE_LIMIT_PER_DAY=10000

--- a/backend/src/services/ai/cache.ts
+++ b/backend/src/services/ai/cache.ts
@@ -10,6 +10,7 @@
 import * as crypto from 'crypto';
 import { redis } from '../../lib/redis';
 import { AIResponse, Embedding } from './types';
+import { getConfigManager } from './config';
 
 export interface CacheConfig {
   enabled: boolean;
@@ -231,10 +232,7 @@ let cacheInstance: AICache | null = null;
 
 export function getCache(config?: CacheConfig): AICache {
   if (!cacheInstance) {
-    const finalConfig: CacheConfig = config || {
-      enabled: process.env.AI_CACHE_ENABLED === 'true',
-      ttlSeconds: parseInt(process.env.AI_CACHE_TTL_SECONDS || '604800', 10),
-    };
+    const finalConfig = config || getConfigManager().getCacheConfig();
     cacheInstance = new AICache(finalConfig);
   }
   return cacheInstance;

--- a/backend/src/services/ai/config.ts
+++ b/backend/src/services/ai/config.ts
@@ -23,6 +23,15 @@ const DEFAULT_CONFIG: AIConfig = {
     nlQueries: false,
     ticketGeneration: true,
   },
+  providerSettings: {
+    maxTokens: 4096,
+    temperature: 1.0,
+    timeoutMs: 60000,
+  },
+  providerSecrets: {},
+  vectorDB: {
+    url: 'http://localhost:8080',
+  },
   cost: {
     monthlyBudgetUSD: 100,
     alertThresholdPercent: 80,
@@ -112,6 +121,15 @@ export class AIConfigManager {
         nlQueries: yaml.features.nl_queries,
         ticketGeneration: yaml.features.ticket_generation,
       } : undefined,
+      providerSettings: yaml.provider_settings ? {
+        maxTokens: yaml.provider_settings.max_tokens,
+        temperature: yaml.provider_settings.temperature,
+        timeoutMs: yaml.provider_settings.timeout_ms,
+      } : undefined,
+      vectorDB: yaml.vector_db ? {
+        url: yaml.vector_db.url,
+        apiKey: yaml.vector_db.api_key,
+      } : undefined,
       cost: yaml.cost ? {
         monthlyBudgetUSD: yaml.cost.monthly_budget_usd,
         alertThresholdPercent: yaml.cost.alert_threshold_percent,
@@ -187,6 +205,37 @@ export class AIConfigManager {
       };
     }
 
+    // Provider settings
+    if (env.AI_MAX_TOKENS || env.AI_TEMPERATURE || env.AI_TIMEOUT_MS) {
+      config.providerSettings = {
+        maxTokens: parseInt(env.AI_MAX_TOKENS || '4096', 10),
+        temperature: parseFloat(env.AI_TEMPERATURE || '1.0'),
+        timeoutMs: parseInt(env.AI_TIMEOUT_MS || '60000', 10),
+      };
+    }
+
+    // Provider secrets (always load if present — these are sensitive)
+    config.providerSecrets = {
+      anthropicApiKey: env.ANTHROPIC_API_KEY || undefined,
+      openaiApiKey: env.OPENAI_API_KEY || undefined,
+      openaiOrgId: env.OPENAI_ORG_ID || undefined,
+      googleApiKey: env.GOOGLE_API_KEY || undefined,
+      azureOpenaiKey: env.AZURE_OPENAI_KEY || undefined,
+      azureOpenaiEndpoint: env.AZURE_OPENAI_ENDPOINT || undefined,
+      azureDeploymentName: env.AZURE_DEPLOYMENT_NAME || undefined,
+      openrouterApiKey: env.OPENROUTER_API_KEY || undefined,
+      openrouterSiteUrl: env.OPENROUTER_SITE_URL || undefined,
+      openrouterAppName: env.OPENROUTER_APP_NAME || undefined,
+    };
+
+    // Vector DB
+    if (env.WEAVIATE_URL || env.WEAVIATE_API_KEY) {
+      config.vectorDB = {
+        url: env.WEAVIATE_URL || 'http://localhost:8080',
+        apiKey: env.WEAVIATE_API_KEY || undefined,
+      };
+    }
+
     return config;
   }
 
@@ -244,6 +293,44 @@ export class AIConfigManager {
    */
   getRateLimitConfig() {
     return { ...this.config.rateLimit };
+  }
+
+  /**
+   * Get provider settings (maxTokens, temperature, timeout)
+   */
+  getProviderSettings() {
+    return { ...this.config.providerSettings };
+  }
+
+  /**
+   * Get provider secrets (API keys and related credentials)
+   */
+  getProviderSecrets() {
+    return { ...this.config.providerSecrets };
+  }
+
+  /**
+   * Get the API key for the currently configured provider
+   */
+  getApiKeyForProvider(provider?: AIProviderName): string {
+    const p = provider || this.config.provider;
+    const secrets = this.config.providerSecrets;
+    switch (p) {
+      case 'anthropic': return secrets.anthropicApiKey || '';
+      case 'openai': return secrets.openaiApiKey || '';
+      case 'google': return secrets.googleApiKey || '';
+      case 'azure': return secrets.azureOpenaiKey || '';
+      case 'openrouter': return secrets.openrouterApiKey || '';
+      case 'mock': return 'mock-key';
+      default: return '';
+    }
+  }
+
+  /**
+   * Get vector DB configuration
+   */
+  getVectorDBConfig() {
+    return { ...this.config.vectorDB };
   }
 
   /**

--- a/backend/src/services/ai/index.ts
+++ b/backend/src/services/ai/index.ts
@@ -20,6 +20,7 @@ export { AzureProvider, AzureProviderConfig } from './providers/azure.provider';
 export {
   providerRegistry,
   getProvider,
+  createProviderFromConfig,
   createProviderFromEnv,
   listAvailableProviders,
 } from './providers/registry';

--- a/backend/src/services/ai/manager.ts
+++ b/backend/src/services/ai/manager.ts
@@ -8,7 +8,7 @@
 import { Pool } from 'pg';
 import { AIConfigManager, getConfigManager } from './config';
 import { BaseProvider } from './providers/base.provider';
-import { createProviderFromEnv } from './providers/registry';
+import { createProviderFromConfig } from './providers/registry';
 import { MockProvider } from './providers/mock.provider';
 import { WeaviateVectorClient, getVectorClient } from './vector/client';
 import { initializeSchemas } from './vector/schema';
@@ -48,7 +48,7 @@ export class AIManager {
   constructor(config: AIManagerConfig) {
     this.db = config.db;
     this.configManager = getConfigManager();
-    this.cache = getCache();
+    this.cache = getCache(this.configManager.getCacheConfig());
     this.costTracker = getCostTracker(this.db, this.configManager.getCostConfig());
     this.contextEnrichment = new ContextEnrichmentService();
   }
@@ -82,8 +82,8 @@ export class AIManager {
       await this.costTracker.initialize();
       console.log('✅ Cost tracker initialized');
 
-      // Initialize AI provider
-      this.provider = createProviderFromEnv();
+      // Initialize AI provider from central config
+      this.provider = createProviderFromConfig(this.configManager);
       // this.provider = new MockProvider({ apiKey: 'mock', model: 'mock' });
       this.contextEnrichment.setProvider(this.provider);
       console.log(`✅ AI provider initialized: ${this.provider.getName()}`);
@@ -103,7 +103,7 @@ export class AIManager {
       // Initialize vector database
       if (this.configManager.isFeatureEnabled('rcaMatching')) {
         try {
-          this.vectorClient = getVectorClient();
+          this.vectorClient = getVectorClient(this.configManager.getVectorDBConfig());
           await this.vectorClient.connect();
           await initializeSchemas(this.vectorClient);
           console.log('✅ Vector database initialized');

--- a/backend/src/services/ai/providers/registry.ts
+++ b/backend/src/services/ai/providers/registry.ts
@@ -6,6 +6,7 @@
  */
 
 import { AIProviderName } from '../types';
+import { AIConfigManager, getConfigManager } from '../config';
 import { BaseProvider, ProviderConfig } from './base.provider';
 import { AnthropicProvider } from './anthropic.provider';
 import { OpenAIProvider } from './openai.provider';
@@ -69,63 +70,47 @@ class ProviderRegistry {
   }
 
   /**
-   * Create a provider from environment variables
+   * Create a provider from AIConfigManager (central config source)
    */
-  createFromEnv(): BaseProvider {
-    const providerName = (process.env.AI_PROVIDER || 'anthropic') as AIProviderName;
-    const model = process.env.AI_MODEL || this.getDefaultModel(providerName);
+  createFromConfig(configManager?: AIConfigManager): BaseProvider {
+    const cm = configManager || getConfigManager();
+    const providerName = cm.getProvider();
+    const model = cm.getModel() || this.getDefaultModel(providerName);
+    const settings = cm.getProviderSettings();
+    const secrets = cm.getProviderSecrets();
 
-    const config = this.getConfigFromEnv(providerName, model);
-    return this.getProvider(providerName, config);
+    const baseConfig: ProviderConfig = {
+      apiKey: cm.getApiKeyForProvider(providerName),
+      model,
+      maxTokens: settings.maxTokens,
+      temperature: settings.temperature,
+      timeout: settings.timeoutMs,
+    };
+
+    // Add provider-specific config
+    switch (providerName) {
+      case 'openai':
+        (baseConfig as any).orgId = secrets.openaiOrgId;
+        break;
+      case 'azure':
+        (baseConfig as any).endpoint = secrets.azureOpenaiEndpoint;
+        (baseConfig as any).deploymentName = secrets.azureDeploymentName;
+        break;
+      case 'openrouter':
+        (baseConfig as any).siteUrl = secrets.openrouterSiteUrl;
+        (baseConfig as any).appName = secrets.openrouterAppName;
+        break;
+    }
+
+    return this.getProvider(providerName, baseConfig);
   }
 
   /**
-   * Get provider configuration from environment variables
+   * Create a provider from environment variables
+   * @deprecated Use createFromConfig() instead — reads from AIConfigManager
    */
-  private getConfigFromEnv(provider: AIProviderName, model: string): ProviderConfig {
-    const baseConfig: ProviderConfig = {
-      apiKey: '',
-      model,
-      maxTokens: parseInt(process.env.AI_MAX_TOKENS || '4096', 10),
-      temperature: parseFloat(process.env.AI_TEMPERATURE || '1.0'),
-      timeout: parseInt(process.env.AI_TIMEOUT_MS || '60000', 10),
-    };
-
-    switch (provider) {
-      case 'anthropic':
-        baseConfig.apiKey = process.env.ANTHROPIC_API_KEY || '';
-        break;
-
-      case 'openai':
-        baseConfig.apiKey = process.env.OPENAI_API_KEY || '';
-        (baseConfig as any).orgId = process.env.OPENAI_ORG_ID;
-        break;
-
-      case 'google':
-        baseConfig.apiKey = process.env.GOOGLE_API_KEY || '';
-        break;
-
-      case 'azure':
-        baseConfig.apiKey = process.env.AZURE_OPENAI_KEY || '';
-        (baseConfig as any).endpoint = process.env.AZURE_OPENAI_ENDPOINT;
-        (baseConfig as any).deploymentName = process.env.AZURE_DEPLOYMENT_NAME;
-        break;
-
-      case 'openrouter':
-        baseConfig.apiKey = process.env.OPENROUTER_API_KEY || '';
-        (baseConfig as any).siteUrl = process.env.OPENROUTER_SITE_URL;
-        (baseConfig as any).appName = process.env.OPENROUTER_APP_NAME;
-        break;
-
-      case 'mock':
-        baseConfig.apiKey = 'mock-key';
-        break;
-
-      default:
-        throw new Error(`Unknown provider: ${provider}`);
-    }
-
-    return baseConfig;
+  createFromEnv(): BaseProvider {
+    return this.createFromConfig();
   }
 
   /**
@@ -148,13 +133,9 @@ class ProviderRegistry {
    * Check if a provider is available (has API key configured)
    */
   isProviderAvailable(provider: AIProviderName): boolean {
-    try {
-      const model = this.getDefaultModel(provider);
-      const config = this.getConfigFromEnv(provider, model);
-      return !!config.apiKey;
-    } catch {
-      return false;
-    }
+    const cm = getConfigManager();
+    const apiKey = cm.getApiKeyForProvider(provider);
+    return !!apiKey;
   }
 
   /**
@@ -181,8 +162,13 @@ export function getProvider(name: AIProviderName, config: ProviderConfig): BaseP
   return providerRegistry.getProvider(name, config);
 }
 
+export function createProviderFromConfig(configManager?: AIConfigManager): BaseProvider {
+  return providerRegistry.createFromConfig(configManager);
+}
+
+/** @deprecated Use createProviderFromConfig() instead */
 export function createProviderFromEnv(): BaseProvider {
-  return providerRegistry.createFromEnv();
+  return providerRegistry.createFromConfig();
 }
 
 export function listAvailableProviders(): AIProviderName[] {

--- a/backend/src/services/ai/types.ts
+++ b/backend/src/services/ai/types.ts
@@ -58,6 +58,30 @@ export interface AIConfig {
     ticketGeneration: boolean;
   };
 
+  providerSettings: {
+    maxTokens: number;
+    temperature: number;
+    timeoutMs: number;
+  };
+
+  providerSecrets: {
+    anthropicApiKey?: string;
+    openaiApiKey?: string;
+    openaiOrgId?: string;
+    googleApiKey?: string;
+    azureOpenaiKey?: string;
+    azureOpenaiEndpoint?: string;
+    azureDeploymentName?: string;
+    openrouterApiKey?: string;
+    openrouterSiteUrl?: string;
+    openrouterAppName?: string;
+  };
+
+  vectorDB: {
+    url: string;
+    apiKey?: string;
+  };
+
   cost: {
     monthlyBudgetUSD: number;
     alertThresholdPercent: number;

--- a/backend/src/services/ai/vector/client.ts
+++ b/backend/src/services/ai/vector/client.ts
@@ -6,6 +6,7 @@
 
 import weaviate, { WeaviateClient, ApiKey } from 'weaviate-ts-client';
 import { Embedding } from '../types';
+import { getConfigManager } from '../config';
 
 export interface VectorDBConfig {
   url: string;
@@ -324,10 +325,7 @@ let vectorClient: WeaviateVectorClient | null = null;
 
 export function getVectorClient(config?: VectorDBConfig): WeaviateVectorClient {
   if (!vectorClient) {
-    const finalConfig: VectorDBConfig = config || {
-      url: process.env.WEAVIATE_URL || 'http://localhost:8080',
-      apiKey: process.env.WEAVIATE_API_KEY,
-    };
+    const finalConfig = config || getConfigManager().getVectorDBConfig();
     vectorClient = new WeaviateVectorClient(finalConfig);
   }
   return vectorClient;


### PR DESCRIPTION
All AI configuration now flows through a single source of truth: AIConfigManager (config.ts). Subsystems no longer read env vars directly.

Changes:
- types.ts: Extend AIConfig with providerSettings (maxTokens, temperature, timeoutMs), providerSecrets (all API keys), and vectorDB (url, apiKey)
- config.ts: Load all AI env vars centrally (provider settings, API keys, Weaviate config). Add getter methods: getProviderSettings, getProviderSecrets, getApiKeyForProvider, getVectorDBConfig
- registry.ts: Add createProviderFromConfig() that reads from AIConfigManager. Deprecate createProviderFromEnv() (still works, delegates to new method). isProviderAvailable() uses config manager
- cache.ts: getCache() falls back to AIConfigManager instead of reading AI_CACHE_ENABLED/AI_CACHE_TTL_SECONDS directly
- vector/client.ts: getVectorClient() falls back to AIConfigManager instead of reading WEAVIATE_URL/WEAVIATE_API_KEY directly
- manager.ts: Use createProviderFromConfig(), pass config explicitly to getCache() and getVectorClient()
- index.ts: Export createProviderFromConfig alongside deprecated createProviderFromEnv
- .env.example: Document all 25+ AI env vars with sections and defaults
