### PR TITLE
feat: Phase D — production hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.9.0-rc.1] - 2026-02-19
 
-> **Agentic AI Copilot (Backend Complete)** — The full agentic backend is in place: ReAct reasoning loop, 13 tools, confirmation gates, and test intelligence. UI polish (Phase B) pending.
+> **Agentic AI Copilot** — Full agentic backend + 3-column Mission Control UI + consolidated AI config + production hardening.
 
 ---
 
@@ -40,6 +40,28 @@
 - Updated ROADMAP.md to reflect shipped vs. planned status accurately
 - Wired cost tracker budget alerts to existing email notification service
 - Implemented "Clear All" notification functionality in frontend
+
+---
+
+### Production Hardening
+
+**Token Blacklist → Redis** — JWT revocation list migrated from in-memory Map to Redis with automatic TTL expiration. Falls back to in-memory when Redis is unavailable.
+
+**SSRF Validation** — Shared `validateUrlForSSRF()` utility blocks requests to private/internal networks (localhost, RFC 1918, link-local, IPv6 ULA). Applied to Jenkins, Confluence, TestRail, and Monday.com service constructors. Jenkins' existing protection refactored to use the shared utility.
+
+**Notification Persistence** — Replaced 18 hardcoded mock notifications with real Prisma database queries. GET, PATCH (mark read), and DELETE endpoints now operate on the Notification table.
+
+**Performance Monitoring** — Added HTTP response time tracking middleware with circular buffer for p50/p95/p99 computation. AI cache hit/miss rates now exported to Prometheus. New metrics: `testops_http_request_duration_p95_seconds`, `testops_ai_cache_hits_total`, `testops_ai_cache_hit_rate`.
+
+---
+
+### AI Config Consolidation
+
+- All AI environment variables (25+) now load through a single `AIConfigManager`
+- Provider settings (maxTokens, temperature, timeout), API keys, and vector DB config centralized
+- `createProviderFromConfig()` replaces direct env var reads in provider registry
+- Cache and vector client singletons now read config from AIConfigManager
+- `.env.example` updated with all AI env vars organized by section
 
 ---
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -98,6 +98,10 @@ app.use((req: Request, _res: Response, next: NextFunction) => {
   next();
 });
 
+// Response time recording for Prometheus p95/p99 metrics
+import { recordResponseTime } from './middleware/responseTime';
+app.use(recordResponseTime);
+
 // Health check endpoint (no sensitive system info)
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({

--- a/backend/src/middleware/responseTime.ts
+++ b/backend/src/middleware/responseTime.ts
@@ -1,0 +1,55 @@
+/**
+ * Response Time Tracking Middleware
+ *
+ * Records HTTP request durations for Prometheus export.
+ * Uses a fixed-size circular buffer to compute p50/p95/p99 without unbounded memory.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+const BUFFER_SIZE = 10000;
+const durations: number[] = [];
+let totalRequests = 0;
+
+/**
+ * Middleware — must be registered early (before routes) so req.startTime is set.
+ * On response finish, records the duration.
+ */
+export function recordResponseTime(req: Request, res: Response, next: NextFunction): void {
+  const start = req.startTime || Date.now();
+
+  res.on('finish', () => {
+    const durationMs = Date.now() - start;
+    const durationSec = durationMs / 1000;
+    totalRequests++;
+
+    // Circular buffer: overwrite oldest entry
+    if (durations.length < BUFFER_SIZE) {
+      durations.push(durationSec);
+    } else {
+      durations[totalRequests % BUFFER_SIZE] = durationSec;
+    }
+  });
+
+  next();
+}
+
+/**
+ * Get response time percentiles from the buffer.
+ * Returns { p50, p95, p99, count } in seconds.
+ */
+export function getResponseTimeStats(): { p50: number; p95: number; p99: number; count: number } {
+  if (durations.length === 0) {
+    return { p50: 0, p95: 0, p99: 0, count: 0 };
+  }
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const len = sorted.length;
+
+  return {
+    p50: sorted[Math.ceil(0.5 * len) - 1],
+    p95: sorted[Math.ceil(0.95 * len) - 1],
+    p99: sorted[Math.ceil(0.99 * len) - 1],
+    count: totalRequests,
+  };
+}

--- a/backend/src/routes/notification.routes.ts
+++ b/backend/src/routes/notification.routes.ts
@@ -4,8 +4,27 @@ import { validateNotificationPreferences } from '../middleware/validation';
 import { NotificationController } from '../controllers/notification.controller';
 import { UserRole } from '../constants';
 import { notificationRouter as router } from './index';
+import { prisma } from '../lib/prisma';
 
 const notificationController = new NotificationController();
+
+/**
+ * Map Prisma Notification to frontend contract.
+ * DB uses `read`; frontend expects `delivered` + `timestamp`.
+ */
+function toNotificationDTO(n: { id: string; type: string; title: string; message: string; read: boolean; data: string | null; createdAt: Date }) {
+  const data = n.data ? JSON.parse(n.data) : {};
+  return {
+    id: n.id,
+    testRunId: data.testRunId || '',
+    pipelineName: data.pipelineName || n.title,
+    type: n.type,
+    status: data.status || n.type.toUpperCase(),
+    message: n.message,
+    timestamp: n.createdAt.toISOString(),
+    delivered: n.read,
+  };
+}
 
 // @route   GET /api/v1/notifications
 // @desc    Get all notifications for user
@@ -14,234 +33,44 @@ router.get(
   '/',
   authenticate,
   asyncHandler(async (req, res) => {
-    // Return mock notifications for demo - EXPANDED TO 18 NOTIFICATIONS
-    const mockNotifications = [
-      {
-        id: '1',
-        testRunId: 'run-1',
-        pipelineName: 'E2E Test Suite - Production',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Critical test failure detected in production pipeline - 12 tests failing',
-        timestamp: new Date(Date.now() - 1 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '2',
-        testRunId: 'run-2',
-        pipelineName: 'API Integration Tests',
-        type: 'success',
-        status: 'PASSED',
-        message: 'All tests passed successfully - 245 tests completed',
-        timestamp: new Date(Date.now() - 3 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '3',
-        testRunId: 'run-3',
-        pipelineName: 'Security Scan Pipeline',
-        type: 'warning',
-        status: 'WARNING',
-        message: 'Flaky test detected - investigate intermittent failures in auth module',
-        timestamp: new Date(Date.now() - 5 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '4',
-        testRunId: 'run-4',
-        pipelineName: 'Performance Tests',
-        type: 'warning',
-        status: 'WARNING',
-        message: 'Performance degradation detected - response time increased by 25%',
-        timestamp: new Date(Date.now() - 8 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '5',
-        testRunId: 'run-5',
-        pipelineName: 'Mobile App Tests - iOS',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Database migration failed in staging environment',
-        timestamp: new Date(Date.now() - 12 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '6',
-        testRunId: 'run-6',
-        pipelineName: 'Visual Regression Tests',
-        type: 'success',
-        status: 'PASSED',
-        message: 'Visual regression tests passed - UI unchanged',
-        timestamp: new Date(Date.now() - 18 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '7',
-        testRunId: 'run-7',
-        pipelineName: 'Unit Tests - Backend',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Authentication service tests failing - 5 out of 89 tests failed',
-        timestamp: new Date(Date.now() - 24 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '8',
-        testRunId: 'run-8',
-        pipelineName: 'Database Migration Tests',
-        type: 'success',
-        status: 'PASSED',
-        message: 'All migration scripts executed successfully',
-        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '9',
-        testRunId: 'run-9',
-        pipelineName: 'Smoke Tests - Staging',
-        type: 'warning',
-        status: 'WARNING',
-        message: 'Slow response times detected in user registration endpoint',
-        timestamp: new Date(Date.now() - 36 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '10',
-        testRunId: 'run-10',
-        pipelineName: 'Mobile App Tests - Android',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'UI rendering issues on Android 12 devices',
-        timestamp: new Date(Date.now() - 42 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '11',
-        testRunId: 'run-11',
-        pipelineName: 'Accessibility Tests',
-        type: 'warning',
-        status: 'WARNING',
-        message: '15 WCAG compliance violations found in checkout flow',
-        timestamp: new Date(Date.now() - 48 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '12',
-        testRunId: 'run-12',
-        pipelineName: 'Unit Tests - Frontend',
-        type: 'success',
-        status: 'PASSED',
-        message: 'All 567 React component tests passed',
-        timestamp: new Date(Date.now() - 54 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '13',
-        testRunId: 'run-13',
-        pipelineName: 'E2E Test Suite - Production',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Payment processing tests failing - Stripe API integration broken',
-        timestamp: new Date(Date.now() - 60 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '14',
-        testRunId: 'run-14',
-        pipelineName: 'Security Scan Pipeline',
-        type: 'warning',
-        status: 'WARNING',
-        message: '3 high-severity vulnerabilities detected in dependencies',
-        timestamp: new Date(Date.now() - 66 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '15',
-        testRunId: 'run-15',
-        pipelineName: 'Performance Tests',
-        type: 'success',
-        status: 'PASSED',
-        message: 'Load tests completed - system stable under 10k concurrent users',
-        timestamp: new Date(Date.now() - 72 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '16',
-        testRunId: 'run-16',
-        pipelineName: 'API Integration Tests',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Third-party API integration failing - rate limit exceeded',
-        timestamp: new Date(Date.now() - 78 * 3600000).toISOString(),
-        delivered: true
-      },
-      {
-        id: '17',
-        testRunId: 'run-17',
-        pipelineName: 'Visual Regression Tests',
-        type: 'warning',
-        status: 'WARNING',
-        message: 'UI changes detected in 8 components - review screenshots',
-        timestamp: new Date(Date.now() - 84 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '18',
-        testRunId: 'run-18',
-        pipelineName: 'Smoke Tests - Staging',
-        type: 'success',
-        status: 'PASSED',
-        message: 'Staging deployment verified - all smoke tests passed',
-        timestamp: new Date(Date.now() - 90 * 3600000).toISOString(),
-        delivered: true
-      },
-    ];
-    res.status(200).json(mockNotifications);
+    const notifications = await prisma.notification.findMany({
+      where: { userId: req.user!.id },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+    res.status(200).json(notifications.map(toNotificationDTO));
   })
 );
 
 // @route   GET /api/v1/notifications/undelivered
-// @desc    Get undelivered notifications
+// @desc    Get undelivered (unread) notifications
 // @access  Private
 router.get(
   '/undelivered',
   authenticate,
   asyncHandler(async (req, res) => {
-    // Return mock undelivered notifications
-    const mockNotifications = [
-      {
-        id: '1',
-        testRunId: 'run-1',
-        pipelineName: 'E2E Test Suite - Production',
-        type: 'failure',
-        status: 'FAILED',
-        message: 'Critical test failure detected in production pipeline - 12 tests failing',
-        timestamp: new Date(Date.now() - 2 * 3600000).toISOString(),
-        delivered: false
-      },
-      {
-        id: '3',
-        testRunId: 'run-3',
-        pipelineName: 'Security Scan Pipeline',
-        type: 'warning',
-        status: 'WARNING',
-        message: 'Flaky test detected - investigate intermittent failures',
-        timestamp: new Date(Date.now() - 8 * 3600000).toISOString(),
-        delivered: false
-      },
-    ];
-    res.status(200).json(mockNotifications);
+    const notifications = await prisma.notification.findMany({
+      where: { userId: req.user!.id, read: false },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+    res.status(200).json(notifications.map(toNotificationDTO));
   })
 );
 
 // @route   PATCH /api/v1/notifications/:id/delivered
-// @desc    Mark notification as delivered
+// @desc    Mark notification as delivered (read)
 // @access  Private
 router.patch(
   '/:id/delivered',
   authenticate,
   asyncHandler(async (req, res) => {
+    const notificationId = String(req.params.id);
+    const userId = String(req.user!.id);
+    await prisma.notification.updateMany({
+      where: { id: notificationId, userId },
+      data: { read: true },
+    });
     res.status(200).json({ success: true, message: 'Notification marked as delivered' });
   })
 );
@@ -253,6 +82,11 @@ router.delete(
   '/:id',
   authenticate,
   asyncHandler(async (req, res) => {
+    const notificationId = String(req.params.id);
+    const userId = String(req.user!.id);
+    await prisma.notification.deleteMany({
+      where: { id: notificationId, userId },
+    });
     res.status(200).json({ success: true, message: 'Notification deleted' });
   })
 );
@@ -264,8 +98,7 @@ router.delete(
   '/',
   authenticate,
   asyncHandler(async (req, res) => {
-    // When notification persistence is implemented, this will call:
-    // await prisma.notification.deleteMany({ where: { userId: req.user!.id } });
+    await prisma.notification.deleteMany({ where: { userId: req.user!.id } });
     res.status(200).json({ success: true, message: 'All notifications cleared' });
   })
 );

--- a/backend/src/services/__tests__/tokenBlacklist.service.test.ts
+++ b/backend/src/services/__tests__/tokenBlacklist.service.test.ts
@@ -1,6 +1,11 @@
-import { tokenBlacklist } from '../tokenBlacklist.service';
+// Mock Redis before importing the service (Redis import triggers config Zod validation)
+jest.mock('@/lib/redis', () => ({
+  redis: {
+    set: jest.fn().mockRejectedValue(new Error('Redis unavailable')),
+    exists: jest.fn().mockRejectedValue(new Error('Redis unavailable')),
+  },
+}));
 
-// Mock the logger to prevent console output during tests
 jest.mock('@/utils/logger', () => ({
   logger: {
     debug: jest.fn(),
@@ -10,21 +15,20 @@ jest.mock('@/utils/logger', () => ({
   },
 }));
 
+import { tokenBlacklist } from '../tokenBlacklist.service';
+
 describe('TokenBlacklistService', () => {
   afterAll(() => {
-    // Clean up the interval timer to prevent open handles
     tokenBlacklist.destroy();
   });
 
   beforeEach(() => {
-    // Reset the internal blacklist state between tests by destroying and
-    // relying on the exported singleton. We access the private map via
-    // bracket notation for test purposes.
-    (tokenBlacklist as any).blacklist.clear();
+    // Clear the in-memory fallback between tests
+    (tokenBlacklist as any).fallback.clear();
   });
 
-  describe('add', () => {
-    it('should add a token to the blacklist', async () => {
+  describe('add (fallback mode)', () => {
+    it('should add a token to the fallback blacklist when Redis is unavailable', async () => {
       await tokenBlacklist.add('test-token-1', 60000);
 
       const isBlacklisted = await tokenBlacklist.isBlacklisted('test-token-1');
@@ -47,75 +51,54 @@ describe('TokenBlacklistService', () => {
     });
 
     it('should return true for a token that has been added and is not expired', async () => {
-      await tokenBlacklist.add('active-token', 300000); // 5 minutes
-
+      await tokenBlacklist.add('active-token', 300000);
       const result = await tokenBlacklist.isBlacklisted('active-token');
       expect(result).toBe(true);
     });
 
     it('should return false for a token whose blacklist entry has expired', async () => {
-      // Add a token that expired 1 second ago (negative TTL effectively)
-      // We manipulate the internal map directly for this edge case
-      (tokenBlacklist as any).blacklist.set('expired-token', Date.now() - 1000);
+      (tokenBlacklist as any).fallback.set('expired-token', Date.now() - 1000);
 
       const result = await tokenBlacklist.isBlacklisted('expired-token');
       expect(result).toBe(false);
     });
 
-    it('should remove an expired token from the blacklist on access', async () => {
-      (tokenBlacklist as any).blacklist.set('expired-token-2', Date.now() - 1000);
+    it('should remove an expired token from the fallback on access', async () => {
+      (tokenBlacklist as any).fallback.set('expired-token-2', Date.now() - 1000);
 
-      // First call should detect expiry and remove it
       await tokenBlacklist.isBlacklisted('expired-token-2');
 
-      // Verify it was removed from the internal map
-      expect((tokenBlacklist as any).blacklist.has('expired-token-2')).toBe(false);
+      expect((tokenBlacklist as any).fallback.has('expired-token-2')).toBe(false);
     });
   });
 
-  describe('cleanup', () => {
-    it('should remove expired tokens during cleanup', () => {
-      const now = Date.now();
+  describe('Redis integration', () => {
+    it('should try Redis first, then fall back to in-memory', async () => {
+      const { redis } = require('@/lib/redis');
 
-      // Add expired tokens directly to the internal map
-      (tokenBlacklist as any).blacklist.set('expired-1', now - 5000);
-      (tokenBlacklist as any).blacklist.set('expired-2', now - 10000);
-      // Add a valid token
-      (tokenBlacklist as any).blacklist.set('valid-1', now + 60000);
+      await tokenBlacklist.add('redis-test', 60000);
 
-      // Call the private cleanup method
-      (tokenBlacklist as any).cleanup();
+      // Redis was called (even though it failed)
+      expect(redis.set).toHaveBeenCalled();
 
-      // Expired tokens should be removed
-      expect((tokenBlacklist as any).blacklist.has('expired-1')).toBe(false);
-      expect((tokenBlacklist as any).blacklist.has('expired-2')).toBe(false);
-      // Valid token should still exist
-      expect((tokenBlacklist as any).blacklist.has('valid-1')).toBe(true);
+      // Token was still stored in fallback
+      expect(await tokenBlacklist.isBlacklisted('redis-test')).toBe(true);
     });
 
-    it('should not remove tokens that have not yet expired', () => {
-      const now = Date.now();
+    it('should use Redis exists when available', async () => {
+      const { redis } = require('@/lib/redis');
 
-      (tokenBlacklist as any).blacklist.set('future-token', now + 300000);
+      // Make Redis return that the key exists
+      (redis.exists as jest.Mock).mockResolvedValueOnce(1);
 
-      (tokenBlacklist as any).cleanup();
-
-      expect((tokenBlacklist as any).blacklist.has('future-token')).toBe(true);
-    });
-
-    it('should handle an empty blacklist without errors', () => {
-      (tokenBlacklist as any).blacklist.clear();
-
-      expect(() => {
-        (tokenBlacklist as any).cleanup();
-      }).not.toThrow();
+      const result = await tokenBlacklist.isBlacklisted('redis-token');
+      expect(result).toBe(true);
+      expect(redis.exists).toHaveBeenCalledWith('token:blacklist:redis-token');
     });
   });
 
   describe('destroy', () => {
-    it('should clear the cleanup interval without throwing', () => {
-      // Create a separate instance to test destroy without affecting the singleton
-      // We just ensure calling destroy does not throw
+    it('should not throw when called', () => {
       expect(() => {
         tokenBlacklist.destroy();
       }).not.toThrow();

--- a/backend/src/services/confluence.service.ts
+++ b/backend/src/services/confluence.service.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/utils/logger';
 import { config } from '@/config';
+import { validateUrlForSSRF } from '@/utils/ssrf-validator';
 
 // Confluence API Types
 export interface ConfluenceConfig {
@@ -92,6 +93,8 @@ export class ConfluenceService {
     }
 
     try {
+      validateUrlForSSRF(config.confluence.baseUrl);
+
       const auth = Buffer.from(
         `${config.confluence.username}:${config.confluence.apiToken}`
       ).toString('base64');

--- a/backend/src/services/jenkins.service.ts
+++ b/backend/src/services/jenkins.service.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { Pipeline, TestRun } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/utils/logger';
+import { validateUrlForSSRF, validateSameOrigin } from '@/utils/ssrf-validator';
 
 interface JenkinsConfig {
   url: string;
@@ -44,41 +45,7 @@ export class JenkinsService {
    * Validates that a URL is not targeting internal/private networks (SSRF protection)
    */
   private validateUrl(url: string): void {
-    let parsed: URL;
-    try {
-      parsed = new URL(url);
-    } catch {
-      throw new Error('Invalid URL format');
-    }
-
-    // Only allow http(s) protocols
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      throw new Error('Only HTTP(S) URLs are allowed');
-    }
-
-    const hostname = parsed.hostname.toLowerCase();
-
-    // Block private/internal IP ranges and loopback
-    const blockedPatterns = [
-      /^localhost$/i,
-      /^127\./,
-      /^10\./,
-      /^172\.(1[6-9]|2[0-9]|3[01])\./,
-      /^192\.168\./,
-      /^169\.254\./,
-      /^0\./,
-      /^fc00:/i,
-      /^fe80:/i,
-      /^::1$/,
-      /^0:0:0:0:0:0:0:1$/,
-      /^\[::1\]$/,
-    ];
-
-    for (const pattern of blockedPatterns) {
-      if (pattern.test(hostname)) {
-        throw new Error('URLs targeting internal or private networks are not allowed');
-      }
-    }
+    validateUrlForSSRF(url);
   }
 
   private createAuthHeader(credentials: { username: string; apiToken: string }): string {
@@ -144,7 +111,7 @@ export class JenkinsService {
 
       // Get queue item location - validate it stays on same origin (SSRF protection)
       const queueUrl = response.headers.location;
-      this.validateSameOrigin(config.url, queueUrl);
+      this.validateSameOriginUrl(config.url, queueUrl);
       const buildDetails = await this.waitForBuildStart(queueUrl, config.credentials, config.url);
 
       // Update test run with build details
@@ -158,7 +125,7 @@ export class JenkinsService {
 
       // Start monitoring build progress - validate URL stays on same origin
       if (buildDetails.url) {
-        this.validateSameOrigin(config.url, buildDetails.url);
+        this.validateSameOriginUrl(config.url, buildDetails.url);
       }
       this.monitorBuildProgress(buildDetails.url, config.credentials, updatedTestRun);
 
@@ -172,22 +139,11 @@ export class JenkinsService {
   /**
    * Validates that a redirect URL stays on the same origin as the configured Jenkins URL
    */
-  private validateSameOrigin(baseUrl: string, redirectUrl: string): void {
+  private validateSameOriginUrl(baseUrl: string, redirectUrl: string): void {
     if (!redirectUrl) {
       throw new Error('No redirect URL provided');
     }
-    try {
-      const base = new URL(baseUrl);
-      const redirect = new URL(redirectUrl);
-      if (base.origin !== redirect.origin) {
-        throw new Error('Redirect URL does not match Jenkins server origin');
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('origin')) {
-        throw error;
-      }
-      throw new Error('Invalid redirect URL');
-    }
+    validateSameOrigin(baseUrl, redirectUrl);
   }
 
   private async waitForBuildStart(queueUrl: string, credentials: { username: string; apiToken: string }, baseUrl: string): Promise<JenkinsBuildResponse> {

--- a/backend/src/services/metrics.service.ts
+++ b/backend/src/services/metrics.service.ts
@@ -12,6 +12,8 @@ import {
   TopFailingTest,
   PrometheusExportOptions,
 } from '../types/metrics';
+import { getResponseTimeStats } from '../middleware/responseTime';
+import { getCache } from './ai/cache';
 
 export class MetricsService {
   /**
@@ -287,6 +289,58 @@ export class MetricsService {
         { test_name: test.testName }
       );
     });
+
+    // HTTP Response Time Metrics (populated by responseTime middleware)
+    const rtStats = getResponseTimeStats();
+    addMetric(
+      'testops_http_request_duration_p50_seconds',
+      'gauge',
+      'HTTP request duration 50th percentile in seconds',
+      rtStats.p50
+    );
+    addMetric(
+      'testops_http_request_duration_p95_seconds',
+      'gauge',
+      'HTTP request duration 95th percentile in seconds',
+      rtStats.p95
+    );
+    addMetric(
+      'testops_http_request_duration_p99_seconds',
+      'gauge',
+      'HTTP request duration 99th percentile in seconds',
+      rtStats.p99
+    );
+    addMetric(
+      'testops_http_requests_total',
+      'counter',
+      'Total HTTP requests processed',
+      rtStats.count
+    );
+
+    // AI Cache Metrics
+    try {
+      const cacheStats = getCache().getStats();
+      addMetric(
+        'testops_ai_cache_hits_total',
+        'counter',
+        'Total AI cache hits',
+        cacheStats.hits
+      );
+      addMetric(
+        'testops_ai_cache_misses_total',
+        'counter',
+        'Total AI cache misses',
+        cacheStats.misses
+      );
+      addMetric(
+        'testops_ai_cache_hit_rate',
+        'gauge',
+        'AI cache hit rate (0-1)',
+        cacheStats.hitRate
+      );
+    } catch {
+      // AI cache may not be initialized; skip metrics
+    }
 
     return lines.join('\n');
   }

--- a/backend/src/services/monday.service.ts
+++ b/backend/src/services/monday.service.ts
@@ -6,6 +6,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { validateUrlForSSRF } from '@/utils/ssrf-validator';
 import {
   MondayConfig,
   MondayBoard,
@@ -30,6 +31,8 @@ export class MondayService {
       apiUrl: config.apiUrl || 'https://api.monday.com/v2',
       ...config,
     };
+
+    validateUrlForSSRF(this.config.apiUrl!);
 
     this.client = axios.create({
       baseURL: this.config.apiUrl,

--- a/backend/src/services/testrail.service.ts
+++ b/backend/src/services/testrail.service.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/utils/logger';
 import { config } from '@/config';
+import { validateUrlForSSRF } from '@/utils/ssrf-validator';
 
 // TestRail API Types
 export interface TestRailConfig {
@@ -73,6 +74,8 @@ export class TestRailService {
     }
 
     try {
+      validateUrlForSSRF(config.testrail.baseUrl);
+
       const auth = Buffer.from(`${config.testrail.username}:${config.testrail.apiKey}`).toString('base64');
 
       this.client = axios.create({

--- a/backend/src/services/tokenBlacklist.service.ts
+++ b/backend/src/services/tokenBlacklist.service.ts
@@ -1,20 +1,19 @@
+import { redis } from '../lib/redis';
 import { logger } from '../utils/logger';
+
+const KEY_PREFIX = 'token:blacklist:';
 
 /**
  * Token Blacklist Service
  *
- * Maintains a set of revoked JWT tokens. Uses an in-memory store with TTL-based
- * expiration. In production with multiple instances, replace with Redis.
+ * Maintains a set of revoked JWT tokens in Redis with automatic TTL expiration.
+ * Falls back to in-memory Map if Redis is unavailable.
  */
 
 class TokenBlacklistService {
-  private blacklist: Map<string, number> = new Map();
-  private cleanupInterval: ReturnType<typeof setInterval>;
-
-  constructor() {
-    // Clean up expired tokens every 15 minutes
-    this.cleanupInterval = setInterval(() => this.cleanup(), 15 * 60 * 1000);
-  }
+  /** In-memory fallback when Redis is down */
+  private fallback: Map<string, number> = new Map();
+  private fallbackInterval: ReturnType<typeof setInterval> | null = null;
 
   /**
    * Add a token to the blacklist
@@ -22,51 +21,72 @@ class TokenBlacklistService {
    * @param expiresInMs - Time until the token naturally expires (ms)
    */
   async add(token: string, expiresInMs: number): Promise<void> {
-    const expiresAt = Date.now() + expiresInMs;
-    this.blacklist.set(token, expiresAt);
-    logger.debug('Token added to blacklist');
+    const ttlSeconds = Math.ceil(expiresInMs / 1000);
+    try {
+      await redis.set(KEY_PREFIX + token, '1', 'EX', ttlSeconds);
+      logger.debug('Token added to blacklist (Redis)');
+    } catch {
+      // Fallback to in-memory if Redis is unavailable
+      this.ensureFallbackCleanup();
+      this.fallback.set(token, Date.now() + expiresInMs);
+      logger.debug('Token added to blacklist (in-memory fallback)');
+    }
   }
 
   /**
    * Check if a token is blacklisted
    */
   async isBlacklisted(token: string): Promise<boolean> {
-    const expiresAt = this.blacklist.get(token);
-    if (!expiresAt) {
-      return false;
+    try {
+      const result = await redis.exists(KEY_PREFIX + token);
+      if (result) return true;
+    } catch {
+      // Fall through to in-memory check
     }
 
-    // If the blacklist entry has expired, remove it
+    // Check in-memory fallback
+    const expiresAt = this.fallback.get(token);
+    if (!expiresAt) return false;
     if (Date.now() > expiresAt) {
-      this.blacklist.delete(token);
+      this.fallback.delete(token);
       return false;
     }
-
     return true;
   }
 
   /**
-   * Remove expired entries from the blacklist
+   * Start the in-memory fallback cleanup interval (only when fallback is used)
    */
-  private cleanup(): void {
-    const now = Date.now();
-    let removed = 0;
-    for (const [token, expiresAt] of this.blacklist.entries()) {
-      if (now > expiresAt) {
-        this.blacklist.delete(token);
-        removed++;
+  private ensureFallbackCleanup(): void {
+    if (this.fallbackInterval) return;
+    this.fallbackInterval = setInterval(() => {
+      const now = Date.now();
+      let removed = 0;
+      for (const [t, exp] of this.fallback.entries()) {
+        if (now > exp) {
+          this.fallback.delete(t);
+          removed++;
+        }
       }
-    }
-    if (removed > 0) {
-      logger.debug(`Token blacklist cleanup: removed ${removed} expired entries`);
-    }
+      if (removed > 0) {
+        logger.debug(`Token blacklist fallback cleanup: removed ${removed} expired entries`);
+      }
+      // Stop interval when fallback is empty
+      if (this.fallback.size === 0 && this.fallbackInterval) {
+        clearInterval(this.fallbackInterval);
+        this.fallbackInterval = null;
+      }
+    }, 15 * 60 * 1000);
   }
 
   /**
-   * Shutdown the cleanup interval
+   * Shutdown cleanup resources
    */
   destroy(): void {
-    clearInterval(this.cleanupInterval);
+    if (this.fallbackInterval) {
+      clearInterval(this.fallbackInterval);
+      this.fallbackInterval = null;
+    }
   }
 }
 

--- a/backend/src/utils/ssrf-validator.ts
+++ b/backend/src/utils/ssrf-validator.ts
@@ -1,0 +1,66 @@
+/**
+ * SSRF Protection — Shared URL Validator
+ *
+ * Validates that a URL does not target internal/private networks.
+ * Blocks: loopback, RFC 1918 private ranges, link-local, IPv6 ULAs.
+ */
+
+const BLOCKED_HOSTNAME_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,          // Link-local
+  /^0\./,                 // Current network
+  /^fc00:/i,              // IPv6 unique local
+  /^fd[0-9a-f]{2}:/i,    // IPv6 unique local
+  /^fe80:/i,              // IPv6 link-local
+  /^::1$/,                // IPv6 loopback
+  /^0:0:0:0:0:0:0:1$/,   // IPv6 loopback (expanded)
+  /^\[::1\]$/,            // IPv6 loopback (bracketed)
+];
+
+/**
+ * Validates that a URL is safe from SSRF (not targeting private/internal networks).
+ * Throws if the URL is invalid, uses a non-HTTP protocol, or targets a private IP.
+ */
+export function validateUrlForSSRF(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid URL format');
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('Only HTTP(S) URLs are allowed');
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  for (const pattern of BLOCKED_HOSTNAME_PATTERNS) {
+    if (pattern.test(hostname)) {
+      throw new Error('URLs targeting internal or private networks are not allowed');
+    }
+  }
+}
+
+/**
+ * Validates that a redirect URL stays on the same origin as the original URL.
+ * Prevents SSRF via open-redirect chains.
+ */
+export function validateSameOrigin(originalUrl: string, redirectUrl: string | undefined | null): void {
+  if (!redirectUrl) return;
+
+  try {
+    const original = new URL(originalUrl);
+    const redirect = new URL(redirectUrl);
+    if (original.origin !== redirect.origin) {
+      throw new Error('Redirect URL does not match the original origin');
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('origin')) throw err;
+    throw new Error('Invalid redirect URL');
+  }
+}

--- a/specs/SECURITY.md
+++ b/specs/SECURITY.md
@@ -217,8 +217,8 @@ LLM proposes write tool → PendingAction created (DB) → SSE notification → 
 
 | Gap | Severity | Status | Mitigation |
 |-----|----------|--------|------------|
-| Token blacklist in-memory | Medium | Known | Migrate to Redis TTL set |
-| No SSRF validation on external URLs | Medium | Known | Add private-IP blocklist + protocol/port validation |
+| Token blacklist in-memory | Medium | **Resolved** | Migrated to Redis with TTL; in-memory fallback when Redis unavailable |
+| No SSRF validation on external URLs | Medium | **Resolved** | Shared `validateUrlForSSRF()` in `utils/ssrf-validator.ts`; applied to Jenkins, Confluence, TestRail, Monday.com |
 | Single CORS origin | Low | Known | Multi-origin config |
 | No 2FA | Medium | Planned v3.0 | TOTP / WebAuthn |
 | No secret rotation mechanism | Low | Planned | Add rotation API + expiry tracking |


### PR DESCRIPTION
D1: Token blacklist → Redis
  - Replaced in-memory Map with Redis SETEX + automatic TTL
  - In-memory fallback when Redis is unavailable
  - Cleanup interval only activates when fallback is in use
  - Updated tests to mock Redis and verify both paths

D2: SSRF validation on external URLs
  - Created shared validateUrlForSSRF() in utils/ssrf-validator.ts
  - Blocks localhost, RFC 1918, link-local, IPv6 ULA ranges
  - Applied to: Confluence, TestRail, Monday.com constructors
  - Refactored Jenkins to use shared utility (was already inline)
  - Updated specs/SECURITY.md to mark both gaps as resolved

D3: Notification DB persistence
  - Replaced 18 hardcoded mock notifications with Prisma queries
  - GET / — findMany with orderBy/take
  - GET /undelivered — findMany where read=false
  - PATCH /:id/delivered — updateMany to set read=true
  - DELETE /:id — deleteMany scoped to user
  - DELETE / — deleteMany all for user
  - Maps DB `read` field to frontend `delivered` contract

D4: Performance monitoring hooks
  - Created responseTime middleware with 10k circular buffer
  - Computes p50/p95/p99 latency from actual HTTP requests
  - Exports to Prometheus: testops_http_request_duration_p{50,95,99}
  - Exports AI cache metrics: hits, misses, hit rate
  - Wired middleware in app.ts after req.startTime

- [ ] Requires documentation update

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->