### PR TITLE
feat(chat): wire auth context, auto-resume loop, add 48 component tests

### DIFF
--- a/frontend/src/components/AICopilot/AICopilot.tsx
+++ b/frontend/src/components/AICopilot/AICopilot.tsx
@@ -18,6 +18,7 @@ import {
     DeleteOutline as ClearIcon,
 } from '@mui/icons-material';
 import { useAICopilot, ChatMessage } from '../../hooks/useAICopilot';
+import { useAuth } from '../../hooks/useAuth';
 
 // Message components
 import UserMessage from './messages/UserMessage';
@@ -41,10 +42,9 @@ import ChatInput from './ChatInput';
 import EmptyState from './EmptyState';
 import MessageActions from './MessageActions';
 
-// TODO: Get actual user role from auth context. Hardcoded for now.
 function useUserRole(): string {
-    // In production, this would come from auth context: useAuth().user.role
-    return 'EDITOR';
+    const { user } = useAuth();
+    return user?.role?.toUpperCase() || 'VIEWER';
 }
 
 function ConfirmationPreview({ msg, onConfirm, onDeny, userRole }: {

--- a/frontend/src/components/AICopilot/cards/JenkinsStatusCard.test.tsx
+++ b/frontend/src/components/AICopilot/cards/JenkinsStatusCard.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../../test/test-utils';
+import JenkinsStatusCard from './JenkinsStatusCard';
+
+describe('JenkinsStatusCard', () => {
+    const defaultData = {
+        pipeline: { id: 'p1', name: 'auth-service-pipeline', type: 'JENKINS' },
+        recentRuns: [
+            { id: 'r1', name: '482', status: 'PASSED', branch: 'main', passed: 46, failed: 4, skipped: 0, duration: 92000 },
+            { id: 'r2', name: '481', status: 'PASSED', branch: 'main', passed: 50, failed: 0, skipped: 0, duration: 88000 },
+            { id: 'r3', name: '480', status: 'FAILED', branch: 'feat', passed: 27, failed: 23, skipped: 0, duration: 121000 },
+        ],
+    };
+
+    it('renders pipeline name', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        expect(screen.getByText('auth-service-pipeline')).toBeInTheDocument();
+    });
+
+    it('derives PASSING status from latest run', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        expect(screen.getByText('PASSING')).toBeInTheDocument();
+    });
+
+    it('renders pass-rate percentages for each run', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        expect(screen.getByText('92%')).toBeInTheDocument();
+        expect(screen.getByText('100%')).toBeInTheDocument();
+        expect(screen.getByText('54%')).toBeInTheDocument();
+    });
+
+    it('renders run names', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        expect(screen.getByText('#482')).toBeInTheDocument();
+        expect(screen.getByText('#481')).toBeInTheDocument();
+        expect(screen.getByText('#480')).toBeInTheDocument();
+    });
+
+    it('renders branch names', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        expect(screen.getAllByText('main').length).toBeGreaterThanOrEqual(2);
+        expect(screen.getByText('feat')).toBeInTheDocument();
+    });
+
+    it('does NOT render any action buttons (read-only)', () => {
+        render(<JenkinsStatusCard data={defaultData} />);
+        // No buttons except possibly external link
+        const buttons = screen.queryAllByRole('button');
+        // Should have no action buttons at all
+        expect(buttons.length).toBe(0);
+    });
+
+    it('derives FAILING status when latest run failed', () => {
+        const failingData = {
+            ...defaultData,
+            recentRuns: [
+                { id: 'r1', name: '483', status: 'FAILED', branch: 'main', passed: 10, failed: 40, skipped: 0 },
+            ],
+        };
+        render(<JenkinsStatusCard data={failingData} />);
+        expect(screen.getByText('FAILING')).toBeInTheDocument();
+    });
+
+    it('handles empty runs gracefully', () => {
+        const emptyData = { pipeline: { id: 'p1', name: 'empty-pipeline' }, recentRuns: [] };
+        render(<JenkinsStatusCard data={emptyData} />);
+        expect(screen.getByText('empty-pipeline')).toBeInTheDocument();
+        expect(screen.getByText('PENDING')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/AICopilot/cards/JiraIssueCard.test.tsx
+++ b/frontend/src/components/AICopilot/cards/JiraIssueCard.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/test-utils';
+import JiraIssueCard from './JiraIssueCard';
+
+const defaultData = {
+    key: 'BUG-456',
+    summary: 'NullPointer in UserService',
+    status: 'In Progress',
+    type: 'Bug',
+    labels: ['regression', 'auth'],
+    assignee: 'Jane Doe',
+};
+
+describe('JiraIssueCard', () => {
+    it('renders issue key, summary, status, and assignee', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" />);
+        expect(screen.getByText('BUG-456')).toBeInTheDocument();
+        expect(screen.getByText('NullPointer in UserService')).toBeInTheDocument();
+        expect(screen.getByText('In Progress')).toBeInTheDocument();
+        expect(screen.getByText('Jane Doe', { exact: false })).toBeInTheDocument();
+    });
+
+    it('renders labels as chips', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" />);
+        expect(screen.getByText('regression')).toBeInTheDocument();
+        expect(screen.getByText('auth')).toBeInTheDocument();
+    });
+
+    it('renders type as chip', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" />);
+        expect(screen.getByText('Bug')).toBeInTheDocument();
+    });
+
+    it('shows action buttons for EDITOR role', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" />);
+        expect(screen.getByText('\u2192 Move to Done')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Comment/ })).toBeInTheDocument();
+    });
+
+    it('hides action buttons for VIEWER role', () => {
+        render(<JiraIssueCard data={defaultData} userRole="VIEWER" />);
+        expect(screen.queryByText('\u2192 Move to Done')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Comment/ })).not.toBeInTheDocument();
+    });
+
+    it('calls onAction with transition prompt when Move to Done is clicked', () => {
+        const onAction = vi.fn();
+        render(<JiraIssueCard data={defaultData} userRole="ADMIN" onAction={onAction} />);
+        fireEvent.click(screen.getByText('\u2192 Move to Done'));
+        expect(onAction).toHaveBeenCalledWith('Transition BUG-456 to Done');
+    });
+
+    it('opens inline comment form when Comment is clicked', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" />);
+        fireEvent.click(screen.getByRole('button', { name: /Comment/ }));
+        expect(screen.getByPlaceholderText('Add comment...')).toBeInTheDocument();
+    });
+
+    it('calls onAction with comment text when comment is submitted', () => {
+        const onAction = vi.fn();
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" onAction={onAction} />);
+
+        // Open comment form
+        fireEvent.click(screen.getByRole('button', { name: /Comment/ }));
+
+        // Type and submit
+        const textarea = screen.getByPlaceholderText('Add comment...');
+        fireEvent.change(textarea, { target: { value: 'Root cause found' } });
+        fireEvent.click(screen.getByText('Send'));
+
+        expect(onAction).toHaveBeenCalledWith('Add comment to BUG-456: Root cause found');
+    });
+
+    it('disables Move to Done when status is already Done', () => {
+        const doneData = { ...defaultData, status: 'Done' };
+        render(<JiraIssueCard data={doneData} userRole="EDITOR" />);
+        const btn = screen.getByText('\u2192 Move to Done');
+        expect(btn.closest('button')).toBeDisabled();
+    });
+
+    it('shows spinner text when cardState is action_pending', () => {
+        render(<JiraIssueCard data={defaultData} userRole="EDITOR" cardState="action_pending" />);
+        expect(screen.getByText('\u25CC Moving...')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/AICopilot/cards/shared/CardActions.test.tsx
+++ b/frontend/src/components/AICopilot/cards/shared/CardActions.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../../../test/test-utils';
+import CardActions, { canAct } from './CardActions';
+import { Button } from '@mui/material';
+
+describe('CardActions', () => {
+    it('renders children for ADMIN role', () => {
+        render(
+            <CardActions userRole="ADMIN">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.getByText('Action')).toBeInTheDocument();
+    });
+
+    it('renders children for EDITOR role', () => {
+        render(
+            <CardActions userRole="EDITOR">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.getByText('Action')).toBeInTheDocument();
+    });
+
+    it('renders children for USER role (same level as EDITOR)', () => {
+        render(
+            <CardActions userRole="USER">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.getByText('Action')).toBeInTheDocument();
+    });
+
+    it('hides children for BILLING role', () => {
+        render(
+            <CardActions userRole="BILLING">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.queryByText('Action')).not.toBeInTheDocument();
+    });
+
+    it('hides children for VIEWER role', () => {
+        render(
+            <CardActions userRole="VIEWER">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.queryByText('Action')).not.toBeInTheDocument();
+    });
+
+    it('hides children for unknown role', () => {
+        render(
+            <CardActions userRole="unknown">
+                <Button>Action</Button>
+            </CardActions>
+        );
+        expect(screen.queryByText('Action')).not.toBeInTheDocument();
+    });
+});
+
+describe('canAct', () => {
+    it('returns true for ADMIN', () => {
+        expect(canAct('ADMIN')).toBe(true);
+    });
+
+    it('returns true for EDITOR', () => {
+        expect(canAct('EDITOR')).toBe(true);
+    });
+
+    it('returns true for USER', () => {
+        expect(canAct('USER')).toBe(true);
+    });
+
+    it('returns false for BILLING', () => {
+        expect(canAct('BILLING')).toBe(false);
+    });
+
+    it('returns false for VIEWER', () => {
+        expect(canAct('VIEWER')).toBe(false);
+    });
+
+    it('handles case-insensitive input', () => {
+        expect(canAct('admin')).toBe(true);
+        expect(canAct('viewer')).toBe(false);
+    });
+});

--- a/frontend/src/components/AICopilot/cards/shared/ConfirmationShell.test.tsx
+++ b/frontend/src/components/AICopilot/cards/shared/ConfirmationShell.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '../../../../test/test-utils';
+import ConfirmationShell from './ConfirmationShell';
+
+const defaultProps = {
+    tool: 'jira_create_issue',
+    actionId: 'action-1',
+    status: 'pending' as const,
+    createdAt: new Date(),
+    userRole: 'EDITOR',
+    onConfirm: vi.fn(),
+    onDeny: vi.fn(),
+};
+
+describe('ConfirmationShell', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders children content', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Preview content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('Preview content')).toBeInTheDocument();
+    });
+
+    it('shows REVIEW label when pending', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('REVIEW')).toBeInTheDocument();
+    });
+
+    it('shows APPROVED label when approved', () => {
+        render(
+            <ConfirmationShell {...defaultProps} status="approved">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('APPROVED')).toBeInTheDocument();
+    });
+
+    it('shows DENIED label when denied', () => {
+        render(
+            <ConfirmationShell {...defaultProps} status="denied">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('DENIED')).toBeInTheDocument();
+    });
+
+    it('shows approve and deny buttons when pending', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('Create Issue', { exact: false })).toBeInTheDocument();
+        expect(screen.getByText('Deny', { exact: false })).toBeInTheDocument();
+    });
+
+    it('hides buttons when resolved', () => {
+        render(
+            <ConfirmationShell {...defaultProps} status="approved">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.queryByText('Deny', { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('calls onConfirm when approve button is clicked', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        fireEvent.click(screen.getByText('Create Issue', { exact: false }));
+        expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onDeny when deny button is clicked', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        fireEvent.click(screen.getByText('Deny', { exact: false }));
+        expect(defaultProps.onDeny).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides approve button for VIEWER role and shows message', () => {
+        render(
+            <ConfirmationShell {...defaultProps} userRole="VIEWER">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.queryByText('Create Issue', { exact: false })).not.toBeInTheDocument();
+        expect(screen.getByText('Requires Editor role')).toBeInTheDocument();
+    });
+
+    it('hides approve button for BILLING role', () => {
+        render(
+            <ConfirmationShell {...defaultProps} userRole="BILLING">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.queryByText('Create Issue', { exact: false })).not.toBeInTheDocument();
+        expect(screen.getByText('Requires Editor role')).toBeInTheDocument();
+    });
+
+    it('shows countdown timer when pending', () => {
+        render(
+            <ConfirmationShell {...defaultProps}>
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('remaining', { exact: false })).toBeInTheDocument();
+    });
+
+    it('shows correct action label for different tools', () => {
+        render(
+            <ConfirmationShell {...defaultProps} tool="github_create_pr">
+                <div>Content</div>
+            </ConfirmationShell>
+        );
+        expect(screen.getByText('Create PR', { exact: false })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/AICopilot/messages/ToolResultCard.test.tsx
+++ b/frontend/src/components/AICopilot/messages/ToolResultCard.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../../test/test-utils';
+import ToolResultCard from './ToolResultCard';
+import type { ChatMessage } from '../../../hooks/useAICopilot';
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+    return {
+        id: 'msg-1',
+        role: 'tool_result',
+        content: 'Test summary',
+        toolName: undefined,
+        timestamp: new Date(),
+        cardState: 'idle',
+        ...overrides,
+    };
+}
+
+describe('ToolResultCard', () => {
+    it('renders GenericResultCard when no toolData is provided', () => {
+        render(
+            <ToolResultCard
+                message={makeMessage({ toolName: 'jira_get' })}
+                userRole="EDITOR"
+            />
+        );
+        expect(screen.getByText('Test summary')).toBeInTheDocument();
+    });
+
+    it('renders JiraIssueCard for jira_get with toolData', () => {
+        const msg = makeMessage({
+            toolName: 'jira_get',
+            toolData: {
+                key: 'BUG-123',
+                summary: 'Null pointer error',
+                status: 'In Progress',
+                type: 'Bug',
+                labels: ['regression'],
+                assignee: 'John Doe',
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" />);
+        expect(screen.getByText('BUG-123')).toBeInTheDocument();
+        expect(screen.getByText('Null pointer error')).toBeInTheDocument();
+        expect(screen.getByText('In Progress')).toBeInTheDocument();
+        expect(screen.getByText('John Doe', { exact: false })).toBeInTheDocument();
+    });
+
+    it('renders JiraSearchCard for jira_search with array data', () => {
+        const msg = makeMessage({
+            toolName: 'jira_search',
+            toolData: [
+                { key: 'BUG-1', summary: 'First issue', status: 'Open', type: 'Bug', assignee: 'Alice' },
+                { key: 'BUG-2', summary: 'Second issue', status: 'Done', type: 'Task', assignee: 'Bob' },
+            ] as unknown as Record<string, unknown>,
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" />);
+        expect(screen.getByText('BUG-1')).toBeInTheDocument();
+        expect(screen.getByText('BUG-2')).toBeInTheDocument();
+    });
+
+    it('renders GitHubCommitCard for github_get_commit', () => {
+        const msg = makeMessage({
+            toolName: 'github_get_commit',
+            toolData: {
+                message: 'Fix auth bug',
+                filesChanged: 2,
+                files: [
+                    { filename: 'src/auth.ts', status: 'modified', additions: 5, deletions: 2 },
+                    { filename: 'src/auth.test.ts', status: 'modified', additions: 10, deletions: 0 },
+                ],
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="VIEWER" />);
+        expect(screen.getByText('Fix auth bug')).toBeInTheDocument();
+        expect(screen.getByText('src/auth.ts')).toBeInTheDocument();
+    });
+
+    it('renders JenkinsStatusCard for jenkins_get_status', () => {
+        const msg = makeMessage({
+            toolName: 'jenkins_get_status',
+            toolData: {
+                pipeline: { id: 'p1', name: 'auth-pipeline', type: 'JENKINS' },
+                recentRuns: [
+                    { id: 'r1', name: '42', status: 'PASSED', branch: 'main', passed: 10, failed: 0, skipped: 0 },
+                ],
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="VIEWER" />);
+        expect(screen.getByText('auth-pipeline')).toBeInTheDocument();
+        expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+
+    it('renders MetricsCard for dashboard_metrics', () => {
+        const msg = makeMessage({
+            toolName: 'dashboard_metrics',
+            toolData: {
+                timeRange: 'Last 30 days',
+                totalTestRuns: 142,
+                passedRuns: 130,
+                failedRuns: 12,
+                passRate: '91.5%',
+                failuresArchived: 8,
+                activePipelines: 5,
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" />);
+        expect(screen.getByText('142')).toBeInTheDocument();
+        expect(screen.getByText('91.5%')).toBeInTheDocument();
+    });
+
+    it('renders PredictionCard risk variant for failure_predictions', () => {
+        const msg = makeMessage({
+            toolName: 'failure_predictions',
+            toolData: {
+                scores: [
+                    { testName: 'auth.login.test', score: 87, level: 'CRITICAL', prediction: 'Likely to fail' },
+                ],
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" />);
+        expect(screen.getByText('auth.login.test')).toBeInTheDocument();
+        expect(screen.getByText('87')).toBeInTheDocument();
+        expect(screen.getByText('CRITICAL')).toBeInTheDocument();
+    });
+
+    it('renders GenericResultCard for unknown tool names', () => {
+        const msg = makeMessage({
+            toolName: 'unknown_tool',
+            toolData: { some: 'data' },
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" />);
+        expect(screen.getByText('Test summary')).toBeInTheDocument();
+        expect(screen.getByText('Show raw data', { exact: false })).toBeInTheDocument();
+    });
+
+    it('passes onAction callback through to cards', () => {
+        const onAction = vi.fn();
+        const msg = makeMessage({
+            toolName: 'jira_get',
+            toolData: {
+                key: 'BUG-1',
+                summary: 'Test',
+                status: 'In Progress',
+                type: 'Bug',
+                labels: [],
+                assignee: 'Test',
+            },
+        });
+        render(<ToolResultCard message={msg} userRole="EDITOR" onAction={onAction} />);
+        // Action buttons should be visible for EDITOR role
+        expect(screen.getByText('\u2192 Move to Done')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/hooks/useAICopilot.ts
+++ b/frontend/src/hooks/useAICopilot.ts
@@ -277,17 +277,27 @@ export function useAICopilot(): UseAICopilotReturn {
 
             const result = await response.json();
 
-            // If approved and tool executed successfully, append the result
+            // If approved and tool executed successfully, append the result card
             if (approved && result.toolResult) {
+                const toolName = result.data?.toolName;
                 setMessages(prev => [...prev, {
                     id: generateId(),
                     role: 'tool_result',
                     content: result.toolResult.summary || JSON.stringify(result.toolResult),
-                    toolName: result.data?.toolName,
+                    toolName,
                     toolData: result.toolResult.data as Record<string, unknown> | undefined,
                     cardState: 'idle',
                     timestamp: new Date(),
                 }]);
+
+                // Auto-resume: send a continuation message so the AI can finish
+                // its reasoning with the tool result. Short delay to let the card render.
+                setTimeout(() => {
+                    sendMessage(
+                        `The tool ${toolName || 'action'} was executed successfully. ` +
+                        `Please summarize the result and suggest any follow-up actions.`
+                    );
+                }, 500);
             }
 
         } catch (err) {
@@ -300,7 +310,7 @@ export function useAICopilot(): UseAICopilotReturn {
                 timestamp: new Date(),
             }]);
         }
-    }, []);
+    }, [sendMessage]);
 
     const clearMessages = useCallback(() => {
         abortRef.current?.abort();


### PR DESCRIPTION
- Wire useUserRole() to actual useAuth() context instead of hardcoded 'EDITOR'
- Auto-resume ReAct loop after confirmation approval via sendMessage continuation
- Add 5 test suites (48 tests): ToolResultCard routing, CardActions role gating, JiraIssueCard actions/comments, ConfirmationShell states/timers, JenkinsStatusCard read-only

