### PR TITLE
feat(ai): in-chat provider picker — configure AI provider without lea…

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -314,6 +314,19 @@ model PendingAction {
   @@index([status])
 }
 
+// ─── In-App AI Provider Configuration ───
+
+model AIProviderConfig {
+  id          String   @id @default("singleton")
+  provider    String   @default("mock") // anthropic | openai | google | azure | openrouter | mock
+  model       String   @default("mock-model")
+  apiKey      String?  // AES-256-GCM encrypted
+  extraConfig String?  // JSON: azure endpoint, openrouter app name, etc.
+  updatedBy   String?
+  updatedAt   DateTime @updatedAt
+  createdAt   DateTime @default(now())
+}
+
 // ─── Team Workspaces ───
 
 model Team {

--- a/backend/src/routes/ai/index.ts
+++ b/backend/src/routes/ai/index.ts
@@ -7,7 +7,8 @@
 
 import { Router, Request, Response, IRouter } from 'express';
 import { getAIManager } from '../../services/ai';
-import { authenticate } from '../../middleware/auth';
+import { authenticate, authorize } from '../../middleware/auth';
+import { UserRole } from '../../constants';
 import { TestFailure } from '../../services/ai/types';
 import { RCAMatchingOptions } from '../../services/ai/features/rca-matching';
 import { CategorizationOptions } from '../../services/ai/features/categorization';
@@ -16,6 +17,7 @@ import { EnrichmentInput } from '../../services/ai/features/context-enrichment';
 import { handleChatStream } from '../../services/ai/AIChatService';
 import * as chatSession from '../../services/ai/ChatSessionService';
 import * as confirmation from '../../services/ai/ConfirmationService';
+import * as providerConfig from '../../services/ai/provider-config.service';
 import { toolRegistry } from '../../services/ai/tools';
 import { ToolResult } from '../../services/ai/tools/types';
 import { logger } from '../../utils/logger';
@@ -50,6 +52,100 @@ router.get('/health', async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       error: 'Health check failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+// ─── Provider Configuration (In-Chat AI Picker) ───
+
+/**
+ * GET /api/ai/config
+ * Return current provider configuration (no secrets).
+ */
+router.get('/config', async (_req: Request, res: Response) => {
+  try {
+    const config = await providerConfig.getProviderConfig();
+    return res.json({
+      data: config,
+      providers: providerConfig.PROVIDER_MODELS,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Failed to get provider config',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * PUT /api/ai/config
+ * Update provider configuration. ADMIN only.
+ */
+router.put('/config', authorize(UserRole.ADMIN), async (req: Request, res: Response) => {
+  try {
+    const { provider, model, apiKey, extraConfig } = req.body;
+
+    if (!provider || !model) {
+      return res.status(400).json({ error: 'provider and model are required' });
+    }
+
+    const validProviders = ['anthropic', 'openai', 'google', 'azure', 'openrouter', 'mock'];
+    if (!validProviders.includes(provider)) {
+      return res.status(400).json({ error: `Invalid provider. Must be one of: ${validProviders.join(', ')}` });
+    }
+
+    if (provider !== 'mock' && !apiKey) {
+      // Check if there's already a stored key
+      const existing = await providerConfig.getProviderConfig();
+      if (!existing.hasApiKey) {
+        return res.status(400).json({ error: 'API key is required for non-mock providers' });
+      }
+    }
+
+    const user = (req as any).user || {};
+    const result = await providerConfig.updateProviderConfig(
+      { provider, model, apiKey, extraConfig },
+      user.id || 'unknown',
+    );
+
+    return res.json({ data: result });
+  } catch (error) {
+    logger.error('[AI Config] Update failed:', error);
+    return res.status(500).json({
+      error: 'Failed to update provider config',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * POST /api/ai/config/test
+ * Test a provider connection without saving.
+ */
+router.post('/config/test', async (req: Request, res: Response) => {
+  try {
+    const { provider, model, apiKey, extraConfig } = req.body;
+
+    if (!provider || !model) {
+      return res.status(400).json({ error: 'provider and model are required' });
+    }
+
+    if (provider !== 'mock' && !apiKey) {
+      return res.status(400).json({ error: 'apiKey is required for connection test' });
+    }
+
+    const result = await providerConfig.testProviderConnection(
+      provider,
+      model,
+      apiKey || 'mock-key',
+      extraConfig,
+    );
+
+    return res.json({ data: result });
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Connection test failed',
       message: error instanceof Error ? error.message : 'Unknown error',
     });
   }

--- a/backend/src/services/ai/config.ts
+++ b/backend/src/services/ai/config.ts
@@ -334,6 +334,25 @@ export class AIConfigManager {
   }
 
   /**
+   * Apply a runtime override (e.g. from DB-stored provider config).
+   * Merges the override into the current config without touching disk/env sources.
+   */
+  applyRuntimeOverride(override: Partial<AIConfig>): void {
+    if (override.provider !== undefined) this.config.provider = override.provider;
+    if (override.model !== undefined) this.config.model = override.model;
+    if (override.enabled !== undefined) this.config.enabled = override.enabled;
+    if (override.providerSecrets) {
+      this.config.providerSecrets = { ...this.config.providerSecrets, ...override.providerSecrets };
+    }
+    if (override.providerSettings) {
+      this.config.providerSettings = { ...this.config.providerSettings, ...override.providerSettings };
+    }
+    if (override.features) {
+      this.config.features = { ...this.config.features, ...override.features };
+    }
+  }
+
+  /**
    * Reload configuration from disk
    */
   reload(): void {

--- a/backend/src/services/ai/provider-config.service.ts
+++ b/backend/src/services/ai/provider-config.service.ts
@@ -1,0 +1,321 @@
+/**
+ * AI Provider Configuration Service
+ *
+ * Manages runtime AI provider configuration stored in the database.
+ * API keys are encrypted at rest using AES-256-GCM.
+ * Supports hot-swapping the active provider without server restart.
+ */
+
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+import { AIProviderName } from './types';
+import { getConfigManager } from './config';
+import { providerRegistry } from './providers/registry';
+import { getAIManager } from './manager';
+import { logger } from '@/utils/logger';
+
+// ─── Encryption ───
+
+const ALGORITHM = 'aes-256-gcm';
+const ENCRYPTION_SECRET = process.env.AI_CONFIG_ENCRYPTION_KEY || 'testops-companion-default-enc-key';
+
+function deriveKey(): Buffer {
+    return crypto.scryptSync(ENCRYPTION_SECRET, 'testops-ai-salt', 32);
+}
+
+export function encryptApiKey(plaintext: string): string {
+    const iv = crypto.randomBytes(16);
+    const key = deriveKey();
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const authTag = cipher.getAuthTag().toString('hex');
+    return `${iv.toString('hex')}:${authTag}:${encrypted}`;
+}
+
+export function decryptApiKey(ciphertext: string): string {
+    const [ivHex, authTagHex, encrypted] = ciphertext.split(':');
+    if (!ivHex || !authTagHex || !encrypted) {
+        throw new Error('Invalid encrypted key format');
+    }
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const key = deriveKey();
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+}
+
+// ─── Provider model catalogs (shared with frontend) ───
+
+export const PROVIDER_MODELS: Record<string, { label: string; models: { id: string; label: string }[] }> = {
+    mock: { label: 'Demo Mode', models: [{ id: 'mock-model', label: 'Mock (no API key)' }] },
+    anthropic: {
+        label: 'Anthropic',
+        models: [
+            { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+            { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+        ],
+    },
+    openai: {
+        label: 'OpenAI',
+        models: [
+            { id: 'gpt-4.1', label: 'GPT-4.1' },
+            { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini' },
+            { id: 'gpt-4o', label: 'GPT-4o' },
+            { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+        ],
+    },
+    google: {
+        label: 'Google',
+        models: [
+            { id: 'gemini-3.0-pro', label: 'Gemini 3.0 Pro' },
+            { id: 'gemini-3.0-flash', label: 'Gemini 3.0 Flash' },
+        ],
+    },
+    azure: {
+        label: 'Azure OpenAI',
+        models: [
+            { id: 'gpt-4.1', label: 'GPT-4.1' },
+            { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini' },
+        ],
+    },
+    openrouter: {
+        label: 'OpenRouter',
+        models: [
+            { id: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+            { id: 'openai/gpt-4.1', label: 'GPT-4.1' },
+            { id: 'google/gemini-3.0-flash', label: 'Gemini 3.0 Flash' },
+            { id: 'meta-llama/llama-4-maverick', label: 'Llama 4 Maverick' },
+        ],
+    },
+};
+
+// ─── Public DTOs ───
+
+export interface ProviderConfigPublic {
+    provider: string;
+    model: string;
+    providerLabel: string;
+    modelLabel: string;
+    hasApiKey: boolean;
+    extraConfig?: Record<string, string>;
+    updatedAt: string | null;
+}
+
+export interface ProviderConfigUpdate {
+    provider: AIProviderName;
+    model: string;
+    apiKey?: string;        // plaintext — encrypted before storage
+    extraConfig?: Record<string, string>; // azure endpoint, etc.
+}
+
+// ─── CRUD ───
+
+const SINGLETON_ID = 'singleton';
+
+/**
+ * Get the current provider configuration (safe — no secrets).
+ */
+export async function getProviderConfig(): Promise<ProviderConfigPublic> {
+    const row = await prisma.aIProviderConfig.findUnique({ where: { id: SINGLETON_ID } });
+
+    if (!row) {
+        // No DB config → return current env-based defaults
+        const cm = getConfigManager();
+        const provider = cm.getProvider();
+        const model = cm.getModel();
+        const catalog = PROVIDER_MODELS[provider] || PROVIDER_MODELS.mock;
+        const modelEntry = catalog.models.find(m => m.id === model) || catalog.models[0];
+
+        return {
+            provider,
+            model,
+            providerLabel: catalog.label,
+            modelLabel: modelEntry?.label || model,
+            hasApiKey: provider === 'mock' || !!cm.getApiKeyForProvider(provider),
+            updatedAt: null,
+        };
+    }
+
+    const catalog = PROVIDER_MODELS[row.provider] || PROVIDER_MODELS.mock;
+    const modelEntry = catalog.models.find(m => m.id === row.model) || catalog.models[0];
+
+    return {
+        provider: row.provider,
+        model: row.model,
+        providerLabel: catalog.label,
+        modelLabel: modelEntry?.label || row.model,
+        hasApiKey: row.provider === 'mock' || !!row.apiKey,
+        extraConfig: row.extraConfig ? JSON.parse(row.extraConfig) : undefined,
+        updatedAt: row.updatedAt.toISOString(),
+    };
+}
+
+/**
+ * Update provider configuration + hot-swap the active provider.
+ */
+export async function updateProviderConfig(
+    update: ProviderConfigUpdate,
+    userId: string,
+): Promise<ProviderConfigPublic> {
+    const encryptedKey = update.apiKey ? encryptApiKey(update.apiKey) : undefined;
+
+    // Upsert the singleton row
+    const row = await prisma.aIProviderConfig.upsert({
+        where: { id: SINGLETON_ID },
+        create: {
+            id: SINGLETON_ID,
+            provider: update.provider,
+            model: update.model,
+            apiKey: encryptedKey,
+            extraConfig: update.extraConfig ? JSON.stringify(update.extraConfig) : null,
+            updatedBy: userId,
+        },
+        update: {
+            provider: update.provider,
+            model: update.model,
+            // Only overwrite key if a new one was provided
+            ...(encryptedKey !== undefined ? { apiKey: encryptedKey } : {}),
+            extraConfig: update.extraConfig ? JSON.stringify(update.extraConfig) : undefined,
+            updatedBy: userId,
+        },
+    });
+
+    // Hot-swap the active provider
+    await applyProviderConfig(row.provider as AIProviderName, row.model, update.apiKey, update.extraConfig);
+
+    logger.info(`[ProviderConfig] Provider updated to ${row.provider}/${row.model} by ${userId}`);
+
+    return getProviderConfig();
+}
+
+/**
+ * Test a provider connection without saving.
+ */
+export async function testProviderConnection(
+    provider: AIProviderName,
+    model: string,
+    apiKey: string,
+    extraConfig?: Record<string, string>,
+): Promise<{ success: boolean; latencyMs: number; error?: string }> {
+    const start = Date.now();
+    try {
+        const config: any = {
+            apiKey: provider === 'mock' ? 'mock-key' : apiKey,
+            model,
+            maxTokens: 32,
+            temperature: 0,
+            timeout: 15000,
+        };
+
+        if (provider === 'azure') {
+            config.endpoint = extraConfig?.endpoint || '';
+            config.deploymentName = extraConfig?.deploymentName || model;
+        }
+        if (provider === 'openrouter') {
+            config.siteUrl = extraConfig?.siteUrl || '';
+            config.appName = extraConfig?.appName || 'TestOps Companion';
+        }
+
+        const instance = providerRegistry.getProvider(provider, config);
+        const healthy = await instance.healthCheck();
+
+        // Clear this test instance from cache so it doesn't interfere
+        providerRegistry.clearCache();
+
+        return {
+            success: healthy,
+            latencyMs: Date.now() - start,
+            error: healthy ? undefined : 'Health check returned false',
+        };
+    } catch (err) {
+        providerRegistry.clearCache();
+        return {
+            success: false,
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : 'Connection test failed',
+        };
+    }
+}
+
+/**
+ * Load DB-stored config on server startup and apply if present.
+ */
+export async function loadProviderConfigFromDB(): Promise<void> {
+    try {
+        const row = await prisma.aIProviderConfig.findUnique({ where: { id: SINGLETON_ID } });
+        if (!row || row.provider === 'mock') {
+            logger.info('[ProviderConfig] No DB config or mock — using env-based config');
+            return;
+        }
+
+        const apiKey = row.apiKey ? decryptApiKey(row.apiKey) : '';
+        const extra = row.extraConfig ? JSON.parse(row.extraConfig) : undefined;
+
+        await applyProviderConfig(row.provider as AIProviderName, row.model, apiKey, extra);
+        logger.info(`[ProviderConfig] Loaded DB config: ${row.provider}/${row.model}`);
+    } catch (err) {
+        logger.warn('[ProviderConfig] Failed to load DB config, falling back to env:', err);
+    }
+}
+
+// ─── Internal hot-swap ───
+
+async function applyProviderConfig(
+    provider: AIProviderName,
+    model: string,
+    apiKey?: string,
+    extraConfig?: Record<string, string>,
+): Promise<void> {
+    const cm = getConfigManager();
+
+    // Build the override for the config manager
+    const secretsKey = getSecretsKeyForProvider(provider);
+    const secretsOverride: Record<string, string> = {};
+    if (apiKey && secretsKey) {
+        secretsOverride[secretsKey] = apiKey;
+    }
+    if (provider === 'azure' && extraConfig) {
+        if (extraConfig.endpoint) secretsOverride.azureOpenaiEndpoint = extraConfig.endpoint;
+        if (extraConfig.deploymentName) secretsOverride.azureDeploymentName = extraConfig.deploymentName;
+    }
+    if (provider === 'openrouter' && extraConfig) {
+        if (extraConfig.siteUrl) secretsOverride.openrouterSiteUrl = extraConfig.siteUrl;
+        if (extraConfig.appName) secretsOverride.openrouterAppName = extraConfig.appName;
+    }
+
+    // Apply runtime override to config manager
+    cm.applyRuntimeOverride({
+        enabled: true,
+        provider,
+        model,
+        providerSecrets: secretsOverride as any,
+    });
+
+    // Clear cached provider instances so next request creates a fresh one
+    providerRegistry.clearCache();
+
+    // Force AIManager to rebuild its provider reference
+    try {
+        const manager = getAIManager();
+        (manager as any).provider = providerRegistry.createFromConfig(cm);
+        (manager as any).configManager = cm;
+    } catch {
+        // AIManager may not be initialized yet (startup path)
+    }
+}
+
+function getSecretsKeyForProvider(provider: AIProviderName): string | null {
+    const map: Record<string, string> = {
+        anthropic: 'anthropicApiKey',
+        openai: 'openaiApiKey',
+        google: 'googleApiKey',
+        azure: 'azureOpenaiKey',
+        openrouter: 'openrouterApiKey',
+    };
+    return map[provider] || null;
+}

--- a/frontend/src/components/AICopilot/AICopilot.tsx
+++ b/frontend/src/components/AICopilot/AICopilot.tsx
@@ -41,6 +41,7 @@ import GenericResultCard from './cards/GenericResultCard';
 import ChatInput from './ChatInput';
 import EmptyState from './EmptyState';
 import MessageActions from './MessageActions';
+import ProviderPicker from './ProviderPicker';
 
 function useUserRole(): string {
     const { user } = useAuth();
@@ -179,6 +180,7 @@ export default function AICopilot() {
                     <Typography variant="subtitle2" fontWeight={600}>TestOps Copilot</Typography>
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <ProviderPicker />
                     {isStreaming && (
                         <ThinkingIndicator text="typing" />
                     )}

--- a/frontend/src/components/AICopilot/ProviderPicker.tsx
+++ b/frontend/src/components/AICopilot/ProviderPicker.tsx
@@ -1,0 +1,361 @@
+/**
+ * ProviderPicker — In-chat AI provider configuration popover.
+ *
+ * Shows current provider as a clickable chip in the chat header.
+ * Opens a popover to switch provider, model, and enter API key.
+ * Supports test-connection and live hot-swap without page reload.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+    Box, Typography, Popover, Chip, Button, TextField,
+    Select, MenuItem, InputLabel, FormControl, CircularProgress,
+    IconButton, InputAdornment, Alert, useTheme,
+} from '@mui/material';
+import {
+    Visibility, VisibilityOff,
+    CheckCircle as ConnectedIcon,
+    ErrorOutline as ErrorIcon,
+    SwapHoriz as SwapIcon,
+} from '@mui/icons-material';
+
+// ─── Provider catalog (mirrors backend PROVIDER_MODELS) ───
+
+interface ModelEntry { id: string; label: string }
+interface ProviderEntry { label: string; models: ModelEntry[] }
+
+const PROVIDER_CATALOG: Record<string, ProviderEntry> = {
+    mock: { label: 'Demo Mode', models: [{ id: 'mock-model', label: 'Mock (no API key)' }] },
+    anthropic: {
+        label: 'Anthropic',
+        models: [
+            { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+            { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+        ],
+    },
+    openai: {
+        label: 'OpenAI',
+        models: [
+            { id: 'gpt-4.1', label: 'GPT-4.1' },
+            { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini' },
+            { id: 'gpt-4o', label: 'GPT-4o' },
+            { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+        ],
+    },
+    google: {
+        label: 'Google',
+        models: [
+            { id: 'gemini-3.0-pro', label: 'Gemini 3.0 Pro' },
+            { id: 'gemini-3.0-flash', label: 'Gemini 3.0 Flash' },
+        ],
+    },
+    azure: {
+        label: 'Azure OpenAI',
+        models: [
+            { id: 'gpt-4.1', label: 'GPT-4.1' },
+            { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini' },
+        ],
+    },
+    openrouter: {
+        label: 'OpenRouter',
+        models: [
+            { id: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+            { id: 'openai/gpt-4.1', label: 'GPT-4.1' },
+            { id: 'google/gemini-3.0-flash', label: 'Gemini 3.0 Flash' },
+            { id: 'meta-llama/llama-4-maverick', label: 'Llama 4 Maverick' },
+        ],
+    },
+};
+
+const PROVIDER_ICONS: Record<string, string> = {
+    mock: '\u2B21',         // hexagon
+    anthropic: '\u2728',    // sparkles
+    openai: '\u25CE',       // bullseye
+    google: '\u25C6',       // diamond
+    azure: '\u2601',        // cloud
+    openrouter: '\u21C4',   // arrows
+};
+
+// ─── Types ───
+
+interface ProviderConfig {
+    provider: string;
+    model: string;
+    providerLabel: string;
+    modelLabel: string;
+    hasApiKey: boolean;
+}
+
+type TestStatus = 'idle' | 'testing' | 'success' | 'error';
+
+// ─── Component ───
+
+export default function ProviderPicker() {
+    const theme = useTheme();
+    const isDark = theme.palette.mode === 'dark';
+
+    // Current active config (from backend)
+    const [activeConfig, setActiveConfig] = useState<ProviderConfig>({
+        provider: 'mock', model: 'mock-model',
+        providerLabel: 'Demo Mode', modelLabel: 'Mock',
+        hasApiKey: false,
+    });
+
+    // Form state
+    const [provider, setProvider] = useState('mock');
+    const [model, setModel] = useState('mock-model');
+    const [apiKey, setApiKey] = useState('');
+    const [showKey, setShowKey] = useState(false);
+    const [testStatus, setTestStatus] = useState<TestStatus>('idle');
+    const [testError, setTestError] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [saveError, setSaveError] = useState('');
+
+    // Popover anchor
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const open = Boolean(anchorEl);
+
+    const fetchConfig = useCallback(async () => {
+        try {
+            const token = localStorage.getItem('accessToken');
+            const res = await fetch('/api/v1/ai/config', {
+                headers: token ? { Authorization: `Bearer ${token}` } : {},
+            });
+            if (!res.ok) return;
+            const { data } = await res.json();
+            setActiveConfig(data);
+            setProvider(data.provider);
+            setModel(data.model);
+        } catch {
+            // Silently fail — will show default
+        }
+    }, []);
+
+    useEffect(() => { fetchConfig(); }, [fetchConfig]);
+
+    // Reset model when provider changes
+    useEffect(() => {
+        const catalog = PROVIDER_CATALOG[provider];
+        if (catalog && !catalog.models.some(m => m.id === model)) {
+            setModel(catalog.models[0].id);
+        }
+    }, [provider, model]);
+
+    const handleTest = async () => {
+        setTestStatus('testing');
+        setTestError('');
+        try {
+            const token = localStorage.getItem('accessToken');
+            const res = await fetch('/api/v1/ai/config/test', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                },
+                body: JSON.stringify({ provider, model, apiKey }),
+            });
+            const { data } = await res.json();
+            if (data?.success) {
+                setTestStatus('success');
+            } else {
+                setTestStatus('error');
+                setTestError(data?.error || 'Connection failed');
+            }
+        } catch (err) {
+            setTestStatus('error');
+            setTestError(err instanceof Error ? err.message : 'Network error');
+        }
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        setSaveError('');
+        try {
+            const token = localStorage.getItem('accessToken');
+            const res = await fetch('/api/v1/ai/config', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                },
+                body: JSON.stringify({ provider, model, apiKey: apiKey || undefined }),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.error || `HTTP ${res.status}`);
+            }
+            const { data } = await res.json();
+            setActiveConfig(data);
+            setApiKey('');
+            setTestStatus('idle');
+            setAnchorEl(null);
+        } catch (err) {
+            setSaveError(err instanceof Error ? err.message : 'Save failed');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const catalog = PROVIDER_CATALOG[provider] || PROVIDER_CATALOG.mock;
+    const needsKey = provider !== 'mock';
+    const canSave = provider === 'mock' || activeConfig.hasApiKey || !!apiKey;
+    const isChanged = provider !== activeConfig.provider || model !== activeConfig.model || !!apiKey;
+
+    return (
+        <>
+            {/* Clickable provider badge */}
+            <Chip
+                icon={<span style={{ fontSize: '0.85rem' }}>{PROVIDER_ICONS[activeConfig.provider] || '\u2B21'}</span>}
+                label={activeConfig.provider === 'mock'
+                    ? 'Demo'
+                    : `${activeConfig.providerLabel} \u00B7 ${activeConfig.modelLabel}`
+                }
+                size="small"
+                variant="outlined"
+                onClick={(e) => setAnchorEl(e.currentTarget)}
+                sx={{
+                    cursor: 'pointer',
+                    fontSize: '0.7rem',
+                    height: 26,
+                    borderColor: activeConfig.provider === 'mock'
+                        ? 'text.disabled'
+                        : 'primary.main',
+                    color: activeConfig.provider === 'mock'
+                        ? 'text.secondary'
+                        : 'primary.main',
+                    '& .MuiChip-icon': { ml: 0.5 },
+                    '&:hover': { bgcolor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)' },
+                }}
+            />
+
+            {/* Configuration popover */}
+            <Popover
+                open={open}
+                anchorEl={anchorEl}
+                onClose={() => { setAnchorEl(null); setTestStatus('idle'); setTestError(''); setSaveError(''); }}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                slotProps={{ paper: { sx: { width: 320, p: 2.5, mt: 0.5, borderRadius: 2 } } }}
+            >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                    <SwapIcon fontSize="small" color="primary" />
+                    <Typography variant="subtitle2" fontWeight={600}>AI Provider</Typography>
+                </Box>
+
+                {/* Provider selector */}
+                <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
+                    <InputLabel>Provider</InputLabel>
+                    <Select
+                        value={provider}
+                        label="Provider"
+                        onChange={(e) => { setProvider(e.target.value); setTestStatus('idle'); }}
+                    >
+                        {Object.entries(PROVIDER_CATALOG).map(([key, entry]) => (
+                            <MenuItem key={key} value={key}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <span style={{ fontSize: '0.85rem' }}>{PROVIDER_ICONS[key]}</span>
+                                    {entry.label}
+                                </Box>
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                {/* Model selector */}
+                <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
+                    <InputLabel>Model</InputLabel>
+                    <Select
+                        value={model}
+                        label="Model"
+                        onChange={(e) => { setModel(e.target.value); setTestStatus('idle'); }}
+                    >
+                        {catalog.models.map((m) => (
+                            <MenuItem key={m.id} value={m.id}>{m.label}</MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                {/* API key field (hidden for mock) */}
+                {needsKey && (
+                    <TextField
+                        fullWidth
+                        size="small"
+                        label="API Key"
+                        type={showKey ? 'text' : 'password'}
+                        value={apiKey}
+                        onChange={(e) => { setApiKey(e.target.value); setTestStatus('idle'); }}
+                        placeholder={activeConfig.hasApiKey && activeConfig.provider === provider
+                            ? 'Using stored key (enter new to replace)'
+                            : 'sk-...'}
+                        sx={{ mb: 1.5 }}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        size="small"
+                                        onClick={() => setShowKey(!showKey)}
+                                        edge="end"
+                                    >
+                                        {showKey ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
+                )}
+
+                {/* Test connection status */}
+                {testStatus === 'success' && (
+                    <Alert severity="success" sx={{ mb: 1.5, py: 0 }} icon={<ConnectedIcon fontSize="small" />}>
+                        Connected
+                    </Alert>
+                )}
+                {testStatus === 'error' && (
+                    <Alert severity="error" sx={{ mb: 1.5, py: 0 }} icon={<ErrorIcon fontSize="small" />}>
+                        {testError}
+                    </Alert>
+                )}
+                {saveError && (
+                    <Alert severity="error" sx={{ mb: 1.5, py: 0 }}>
+                        {saveError}
+                    </Alert>
+                )}
+
+                {/* Actions */}
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                    {needsKey && (
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={handleTest}
+                            disabled={testStatus === 'testing' || (!apiKey && !activeConfig.hasApiKey)}
+                            sx={{ flex: 1, textTransform: 'none', fontSize: '0.8rem' }}
+                        >
+                            {testStatus === 'testing'
+                                ? <CircularProgress size={16} sx={{ mr: 0.5 }} />
+                                : null}
+                            Test
+                        </Button>
+                    )}
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={handleSave}
+                        disabled={saving || !canSave || !isChanged}
+                        sx={{ flex: 1, textTransform: 'none', fontSize: '0.8rem' }}
+                    >
+                        {saving
+                            ? <CircularProgress size={16} sx={{ mr: 0.5, color: 'inherit' }} />
+                            : null}
+                        Activate
+                    </Button>
+                </Box>
+
+                <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 1.5, textAlign: 'center', fontSize: '0.65rem' }}>
+                    Keys are encrypted at rest. Switch providers instantly.
+                </Typography>
+            </Popover>
+        </>
+    );
+}


### PR DESCRIPTION
…ving the conversation

Adds the ability to switch AI providers (Anthropic, OpenAI, Google, Azure, OpenRouter, Demo) directly from the chat panel header. Designed for live demos: paste an API key, test the connection, activate — the agentic loop now runs on a real LLM with zero restart.

Backend:
- AIProviderConfig Prisma model (singleton, AES-256-GCM encrypted API key)
- GET/PUT /api/v1/ai/config + POST /api/v1/ai/config/test endpoints
- provider-config.service.ts: encrypt/decrypt, CRUD, hot-swap
- AIConfigManager.applyRuntimeOverride() for live config mutation
- ProviderRegistry cache-clear + AIManager provider swap on update

Frontend:
- ProviderPicker.tsx: popover with provider/model selectors, masked API key field, Test Connection button, Activate button
- Wired into AICopilot header as a clickable chip showing active provider

Supports 6 providers × multiple models each. Mock provider works with no key for default demo mode. Keys encrypted at rest in SQLite.