### PR TITLE
v3.0.0 Phase 1 — Virtual Team Persona Routing

### DIFF
--- a/backend/prisma/schema.dev.prisma
+++ b/backend/prisma/schema.dev.prisma
@@ -267,11 +267,12 @@ model TestResult {
 // ─── AI Copilot Chat Persistence ───
 
 model ChatSession {
-  id        String   @id @default(uuid())
-  userId    String
-  title     String   @default("New Chat")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String   @id @default(uuid())
+  userId         String
+  title          String   @default("New Chat")
+  activePersona  String?  // Last persona used in this session
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   messages       ChatMessage[]
@@ -286,6 +287,7 @@ model ChatMessage {
   role      String   // user | assistant | tool_start | tool_result | thinking | error
   content   String
   toolName  String?
+  persona   String?  // Which virtual team persona generated this message
   createdAt DateTime @default(now())
 
   session ChatSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -267,11 +267,12 @@ model TestResult {
 // ─── AI Copilot Chat Persistence ───
 
 model ChatSession {
-  id        String   @id @default(uuid())
-  userId    String
-  title     String   @default("New Chat")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String   @id @default(uuid())
+  userId         String
+  title          String   @default("New Chat")
+  activePersona  String?  // Last persona used in this session
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   messages       ChatMessage[]
@@ -286,6 +287,7 @@ model ChatMessage {
   role      String   // user | assistant | tool_start | tool_result | thinking | error
   content   String
   toolName  String?
+  persona   String?  // Which virtual team persona generated this message
   createdAt DateTime @default(now())
 
   session ChatSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)

--- a/backend/prisma/schema.production.prisma
+++ b/backend/prisma/schema.production.prisma
@@ -309,11 +309,12 @@ model TestRailRun {
 // ─── AI Copilot Chat Persistence ───
 
 model ChatSession {
-  id        String   @id @default(uuid()) @db.Uuid
-  userId    String   @db.Uuid
-  title     String   @default("New Chat")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String   @id @default(uuid()) @db.Uuid
+  userId         String   @db.Uuid
+  title          String   @default("New Chat")
+  activePersona  String?  // Last persona used in this session
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   messages       ChatMessage[]
@@ -329,6 +330,7 @@ model ChatMessage {
   role      String   // user | assistant | tool_start | tool_result | thinking | error
   content   String
   toolName  String?
+  persona   String?  // Which virtual team persona generated this message
   createdAt DateTime @default(now())
 
   session ChatSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/ai/index.ts
+++ b/backend/src/routes/ai/index.ts
@@ -22,6 +22,7 @@ import { toolRegistry } from '../../services/ai/tools';
 import { ToolResult } from '../../services/ai/tools/types';
 import { getConfigManager } from '../../services/ai/config';
 import { getMockToolResult } from '../../services/ai/mock-tool-results';
+import { getAvailablePersonas } from '../../services/ai/PersonaRouter';
 import { logger } from '../../utils/logger';
 
 const router: IRouter = Router();
@@ -57,6 +58,17 @@ router.get('/health', async (req: Request, res: Response) => {
       message: error instanceof Error ? error.message : 'Unknown error',
     });
   }
+});
+
+// ─── Virtual Team Personas ───
+
+/**
+ * GET /api/ai/personas
+ * List all available virtual team personas with metadata.
+ */
+router.get('/personas', (_req: Request, res: Response) => {
+  const personas = getAvailablePersonas();
+  return res.json({ data: personas });
 });
 
 // ─── Provider Configuration (In-Chat AI Picker) ───

--- a/backend/src/services/ai/AIChatService.ts
+++ b/backend/src/services/ai/AIChatService.ts
@@ -17,6 +17,8 @@ import { SSEEvent, SSEEventType, ToolContext, hasRequiredRole } from './tools/ty
 import { ChatMessage } from './types';
 import { getConfigManager } from './config';
 import { getMockToolResult } from './mock-tool-results';
+import { routeToPersona, PersonaSelection } from './PersonaRouter';
+import { getPersonaInstruction } from './PersonaInstructions';
 import { logger } from '@/utils/logger';
 
 /** Chunk size for token-by-token answer streaming (characters) */
@@ -38,9 +40,9 @@ const MAX_TOOL_CALLS = 5;
 const MAX_REACT_ITERATIONS = 8;
 
 /**
- * Build the system prompt with tool definitions and role context.
+ * Build the system prompt with tool definitions, role context, and persona instructions.
  */
-function buildSystemPrompt(userRole: string): string {
+function buildSystemPrompt(userRole: string, persona?: PersonaSelection): string {
     const toolDefs = toolRegistry.formatForSystemPrompt(/* readOnlyOnly */ false);
 
     const roleGreetings: Record<string, string> = {
@@ -52,9 +54,14 @@ function buildSystemPrompt(userRole: string): string {
 
     const roleContext = roleGreetings[userRole] || roleGreetings.viewer;
 
+    // Persona-specific instructions injected when the router selects a team member
+    const personaBlock = persona
+        ? `\n## Your Role\n${getPersonaInstruction(persona.persona).systemPromptAddon}\n`
+        : '';
+
     return `You are TestOps Copilot, an intelligent assistant for the TestOps Companion platform.
 ${roleContext}
-
+${personaBlock}
 ## Available Tools
 You can use the following tools to look up information. To call a tool, respond with a JSON block like:
 \`\`\`tool_call
@@ -153,7 +160,19 @@ export async function handleChatStream(req: ChatRequest, res: Response): Promise
         return;
     }
 
-    const systemPrompt = buildSystemPrompt(req.userRole);
+    // Route query to the right virtual team persona
+    const persona = await routeToPersona(req.message, req.userRole);
+    logger.info(`[AIChatService] Persona: ${persona.displayName} (${persona.tier}, confidence: ${persona.confidence})`);
+
+    // Emit persona_selected SSE event before the ReAct loop
+    sendSSE(res, createEvent('persona_selected', JSON.stringify({
+        persona: persona.persona,
+        displayName: persona.displayName,
+        confidence: persona.confidence,
+        reasoning: persona.reasoning,
+    })));
+
+    const systemPrompt = buildSystemPrompt(req.userRole, persona);
     const context: ToolContext = {
         userId: req.userId,
         userRole: req.userRole,

--- a/backend/src/services/ai/PersonaInstructions.ts
+++ b/backend/src/services/ai/PersonaInstructions.ts
@@ -1,0 +1,127 @@
+/**
+ * PersonaInstructions — Runtime Persona Configs for System Prompt Injection
+ *
+ * Condensed persona instructions (~200 tokens each) extracted from the full
+ * spec files in specs/team/*.md. These are injected into the system prompt
+ * by AIChatService after the PersonaRouter selects a persona.
+ */
+
+export interface PersonaInstruction {
+    displayName: string;
+    /** Emoji identifier for channel formatting (Slack, Teams) */
+    emoji: string;
+    /** Injected into the system prompt as a "Your Role" block */
+    systemPromptAddon: string;
+    /** Tools this persona prefers — used for context, not hard filtering */
+    preferredTools: string[];
+}
+
+export const PERSONA_INSTRUCTIONS: Record<string, PersonaInstruction> = {
+    SECURITY_ENGINEER: {
+        displayName: 'Security Engineer',
+        emoji: 'shield',
+        systemPromptAddon: `You are responding as the **Security Engineer** on the TestOps team.
+Your expertise: authentication, authorization, secrets management, vulnerability assessment, security posture.
+Prioritize: identifying security risks, ensuring proper access controls, reviewing credential handling,
+and recommending security best practices. Flag any secrets exposure or permission escalation risks.
+When reviewing code or configs, always check for OWASP Top 10 vulnerabilities.`,
+        preferredTools: ['github_get_pr', 'github_get_commit', 'jira_search'],
+    },
+
+    AI_ARCHITECT: {
+        displayName: 'AI Architect',
+        emoji: 'brain',
+        systemPromptAddon: `You are responding as the **AI Architect** on the TestOps team.
+Your expertise: AI system design, provider configuration, prompt engineering, tool policy, trust/explainability.
+Prioritize: ensuring AI behavior is transparent and explainable, managing provider selection and cost,
+designing effective tool policies, and maintaining the trust contract with users.
+Always consider cost, latency, and reliability trade-offs when recommending AI configurations.`,
+        preferredTools: ['dashboard_metrics'],
+    },
+
+    DATA_ENGINEER: {
+        displayName: 'Data Engineer',
+        emoji: 'file_cabinet',
+        systemPromptAddon: `You are responding as the **Data Engineer** on the TestOps team.
+Your expertise: database design, schema management, migrations, query optimization, data integrity.
+Prioritize: ensuring data consistency, optimizing query performance, designing proper indexes,
+and managing schema evolution safely. Check for N+1 queries and missing indexes.
+When discussing schema changes, always consider migration safety and rollback strategies.`,
+        preferredTools: ['dashboard_metrics', 'jira_search'],
+    },
+
+    UX_DESIGNER: {
+        displayName: 'UX Designer',
+        emoji: 'art',
+        systemPromptAddon: `You are responding as the **UX Designer** on the TestOps team.
+Your expertise: user experience design, interaction patterns, visual hierarchy, accessibility, cognitive load.
+Prioritize: clarity over decoration, reducing cognitive load, ensuring accessible design (WCAG 2.1),
+and maintaining consistent interaction patterns. Every UI element should serve a clear purpose.
+When reviewing UI, check for information density, visual hierarchy, and user flow coherence.`,
+        preferredTools: ['dashboard_metrics'],
+    },
+
+    PERFORMANCE_ENGINEER: {
+        displayName: 'Performance Engineer',
+        emoji: 'racing_car',
+        systemPromptAddon: `You are responding as the **Performance Engineer** on the TestOps team.
+Your expertise: latency optimization, throughput analysis, profiling, load testing, resource management.
+Prioritize: identifying performance bottlenecks with data, measuring before optimizing,
+and recommending targeted improvements. Never optimize without profiling data first.
+Always check dashboard_metrics for current performance baselines before making recommendations.`,
+        preferredTools: ['dashboard_metrics', 'jenkins_get_status'],
+    },
+
+    TEST_ENGINEER: {
+        displayName: 'Test Engineer',
+        emoji: 'test_tube',
+        systemPromptAddon: `You are responding as the **Test Engineer** on the TestOps team.
+Your expertise: test strategy, flaky test analysis, coverage gaps, CI quality gates, test isolation.
+Prioritize: identifying root causes of test failures, suggesting test isolation strategies,
+and recommending coverage improvements. Reference test results data and failure patterns.
+When discussing flaky tests, always check failure_predictions and dashboard_metrics tools first.`,
+        preferredTools: ['dashboard_metrics', 'failure_predictions', 'jenkins_get_status'],
+    },
+
+    DEVOPS_ENGINEER: {
+        displayName: 'DevOps Engineer',
+        emoji: 'gear',
+        systemPromptAddon: `You are responding as the **DevOps Engineer** on the TestOps team.
+Your expertise: CI/CD pipelines, Docker, Jenkins, deployment, observability, infrastructure.
+Prioritize: pipeline health, build failures, infrastructure issues, and deployment blockers.
+Always check jenkins_get_status and github_get_pr tools for operational context.
+When troubleshooting, gather pipeline logs and build status before recommending fixes.`,
+        preferredTools: ['jenkins_get_status', 'github_get_pr', 'github_get_commit'],
+    },
+
+    AI_PRODUCT_MANAGER: {
+        displayName: 'Product Manager',
+        emoji: 'compass',
+        systemPromptAddon: `You are responding as the **Product Manager** on the TestOps team.
+Your expertise: feature capabilities, user workflows, product roadmap, use cases, onboarding.
+When users ask what the system can do, give a warm, structured overview of all capabilities.
+Group features by category: Test Intelligence, CI/CD Integration, Knowledge Management,
+AI-Powered Analysis, Collaboration. Suggest specific queries they can try next.
+Help users discover the platform's value and connect features to their workflow needs.`,
+        preferredTools: ['dashboard_metrics'],
+    },
+
+    SENIOR_ENGINEER: {
+        displayName: 'Senior Engineer',
+        emoji: 'wrench',
+        systemPromptAddon: `You are responding as the **Senior Engineer** on the TestOps team.
+Your expertise: general implementation, operational queries, cross-cutting concerns, code quality.
+You're the generalist — handle anything that doesn't fit a specific specialist.
+Prioritize: clean solutions, clear explanations, and practical recommendations.
+Draw on all available tools and data to provide comprehensive answers.`,
+        preferredTools: [],
+    },
+};
+
+/**
+ * Get the persona instruction for a given persona key.
+ * Falls back to SENIOR_ENGINEER if the key is unknown.
+ */
+export function getPersonaInstruction(persona: string): PersonaInstruction {
+    return PERSONA_INSTRUCTIONS[persona] || PERSONA_INSTRUCTIONS.SENIOR_ENGINEER;
+}

--- a/backend/src/services/ai/PersonaRouter.ts
+++ b/backend/src/services/ai/PersonaRouter.ts
@@ -1,0 +1,266 @@
+/**
+ * PersonaRouter — Two-Tier Query Classifier for Virtual Team Routing
+ *
+ * Routes user queries to the right team persona before fulfillment.
+ * Tier 1: Keyword rules (zero cost, <1ms)
+ * Tier 2: LLM micro-classification fallback (~200 tokens)
+ *
+ * Follows the routing rubric in specs/team/TEAM_SELECTION.md:
+ *   Security → AI_ARCHITECT → DATA_ENGINEER → UX_DESIGNER →
+ *   PERFORMANCE_ENGINEER → TEST_ENGINEER → DEVOPS_ENGINEER →
+ *   AI_PRODUCT_MANAGER → SENIOR_ENGINEER (default)
+ */
+
+import { getAIManager } from './manager';
+import { logger } from '@/utils/logger';
+
+// ─── Types ───
+
+export interface PersonaSelection {
+    /** Internal key, e.g. "TEST_ENGINEER" */
+    persona: string;
+    /** Human-readable, e.g. "Test Engineer" */
+    displayName: string;
+    /** 0-1 confidence score */
+    confidence: number;
+    /** Short explanation, e.g. "Query mentions flaky tests" */
+    reasoning: string;
+    /** Which classifier tier produced the result */
+    tier: 'keyword' | 'llm';
+}
+
+// ─── Keyword Rules ───
+
+interface PersonaRule {
+    persona: string;
+    displayName: string;
+    /** Each sub-array is an AND group — all words must appear (case-insensitive). */
+    keywords: string[][];
+    description: string;
+}
+
+/**
+ * Ordered to match the TEAM_SELECTION.md priority rubric.
+ * First match wins (highest-priority persona first).
+ */
+const PERSONA_RULES: PersonaRule[] = [
+    {
+        persona: 'SECURITY_ENGINEER',
+        displayName: 'Security Engineer',
+        keywords: [
+            ['auth'], ['authentication'], ['authorization'],
+            ['permission'], ['secret'], ['vulnerability'],
+            ['cve'], ['security'], ['xss'], ['csrf'], ['injection'],
+            ['token', 'leak'], ['credential'],
+        ],
+        description: 'Authentication, authorization, secrets, security posture',
+    },
+    {
+        persona: 'AI_ARCHITECT',
+        displayName: 'AI Architect',
+        keywords: [
+            ['ai', 'config'], ['ai', 'provider'], ['model', 'switch'],
+            ['tool', 'policy'], ['ai', 'architect'], ['prompt', 'engineering'],
+            ['llm', 'config'],
+        ],
+        description: 'AI configuration, provider selection, tool behavior',
+    },
+    {
+        persona: 'DATA_ENGINEER',
+        displayName: 'Data Engineer',
+        keywords: [
+            ['schema'], ['migration'], ['database'],
+            ['query', 'slow'], ['data', 'integrity'], ['prisma'],
+            ['sql'], ['index', 'missing'],
+        ],
+        description: 'Database, schema, migrations, data integrity',
+    },
+    {
+        persona: 'UX_DESIGNER',
+        displayName: 'UX Designer',
+        keywords: [
+            ['ux'], ['user experience'], ['ui', 'design'],
+            ['layout'], ['accessibility'], ['a11y'],
+            ['responsive'], ['design', 'system'],
+        ],
+        description: 'UX flows, interaction design, visual hierarchy, accessibility',
+    },
+    {
+        persona: 'PERFORMANCE_ENGINEER',
+        displayName: 'Performance Engineer',
+        keywords: [
+            ['slow'], ['latency'], ['timeout'], ['performance'],
+            ['throughput'], ['profiling'], ['memory', 'leak'],
+            ['cpu'], ['bottleneck'], ['load', 'test'],
+        ],
+        description: 'Performance, latency, throughput, profiling',
+    },
+    {
+        persona: 'TEST_ENGINEER',
+        displayName: 'Test Engineer',
+        keywords: [
+            ['flaky', 'test'], ['flaky'], ['test', 'fail'],
+            ['coverage'], ['ci', 'broken'], ['test', 'skip'],
+            ['test', 'strategy'], ['regression'], ['test', 'suite'],
+            ['e2e', 'test'], ['unit', 'test'], ['integration', 'test'],
+        ],
+        description: 'Test failures, flaky tests, CI quality, test coverage',
+    },
+    {
+        persona: 'DEVOPS_ENGINEER',
+        displayName: 'DevOps Engineer',
+        keywords: [
+            ['pipeline'], ['deploy'], ['docker'],
+            ['jenkins', 'build'], ['ci', 'cd'], ['ci/cd'],
+            ['kubernetes'], ['k8s'], ['helm'],
+            ['github', 'action'], ['build', 'fail'],
+        ],
+        description: 'Pipelines, deployments, Docker, CI/CD, build infrastructure',
+    },
+    {
+        persona: 'AI_PRODUCT_MANAGER',
+        displayName: 'Product Manager',
+        keywords: [
+            ['what can'], ['help me'], ['feature'],
+            ['roadmap'], ['capability'], ['what', 'do'],
+            ['how', 'use'], ['getting', 'started'],
+            ['onboarding'], ['use case'],
+        ],
+        description: 'Product capabilities, feature discovery, what the system can do',
+    },
+];
+
+const DEFAULT_PERSONA: PersonaSelection = {
+    persona: 'SENIOR_ENGINEER',
+    displayName: 'Senior Engineer',
+    confidence: 0.5,
+    reasoning: 'No specialist match — routed to generalist',
+    tier: 'keyword',
+};
+
+// ─── Tier 1: Keyword Matching ───
+
+function matchKeywordRules(message: string): PersonaSelection | null {
+    const lower = message.toLowerCase();
+
+    for (const rule of PERSONA_RULES) {
+        for (const group of rule.keywords) {
+            const allMatch = group.every(word => lower.includes(word));
+            if (allMatch) {
+                return {
+                    persona: rule.persona,
+                    displayName: rule.displayName,
+                    confidence: 0.85,
+                    reasoning: `Query matches keyword group: [${group.join(', ')}]`,
+                    tier: 'keyword',
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
+// ─── Tier 2: LLM Micro-Classification ───
+
+const CLASSIFICATION_PROMPT = `You are a query classifier for a TestOps platform's virtual team.
+Classify the user's query into exactly ONE persona from this list:
+
+- SECURITY_ENGINEER: auth, secrets, vulnerabilities, security posture
+- AI_ARCHITECT: AI config, provider selection, LLM behavior, tool policy
+- DATA_ENGINEER: database, schema, migrations, query performance, data integrity
+- UX_DESIGNER: UI/UX flows, design, accessibility, visual hierarchy
+- PERFORMANCE_ENGINEER: latency, throughput, profiling, load testing, memory
+- TEST_ENGINEER: test failures, flaky tests, coverage, CI quality, test strategy
+- DEVOPS_ENGINEER: pipelines, deployments, Docker, CI/CD, build infra
+- AI_PRODUCT_MANAGER: feature discovery, capabilities, roadmap, getting started
+- SENIOR_ENGINEER: general implementation, operational, anything else
+
+Respond with ONLY a JSON object (no markdown, no explanation):
+{"persona": "PERSONA_KEY", "confidence": 0.0-1.0, "reasoning": "brief explanation"}`;
+
+async function classifyWithLLM(message: string): Promise<PersonaSelection> {
+    try {
+        const aiManager = getAIManager();
+
+        if (!aiManager.isInitialized() || !aiManager.isEnabled()) {
+            logger.debug('[PersonaRouter] LLM not available, using default persona');
+            return DEFAULT_PERSONA;
+        }
+
+        const response = await (aiManager as any).provider.chat(
+            [
+                { role: 'system', content: CLASSIFICATION_PROMPT },
+                { role: 'user', content: message },
+            ],
+            { maxTokens: 150, temperature: 0 },
+        );
+
+        const text = response.content.trim();
+        // Extract JSON from response (handle possible markdown wrapping)
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) {
+            logger.warn('[PersonaRouter] LLM returned non-JSON:', text);
+            return DEFAULT_PERSONA;
+        }
+
+        const parsed = JSON.parse(jsonMatch[0]);
+        const persona = parsed.persona as string;
+        const displayName = PERSONA_RULES.find(r => r.persona === persona)?.displayName
+            || (persona === 'SENIOR_ENGINEER' ? 'Senior Engineer' : persona);
+
+        return {
+            persona,
+            displayName,
+            confidence: Math.min(1, Math.max(0, parsed.confidence || 0.7)),
+            reasoning: parsed.reasoning || 'LLM classification',
+            tier: 'llm',
+        };
+    } catch (error) {
+        logger.warn('[PersonaRouter] LLM classification failed, using default:', error);
+        return DEFAULT_PERSONA;
+    }
+}
+
+// ─── Public API ───
+
+/**
+ * Route a user query to the appropriate team persona.
+ * Tier 1 (keyword) is tried first; Tier 2 (LLM) is the fallback.
+ */
+export async function routeToPersona(message: string, _userRole: string): Promise<PersonaSelection> {
+    // Tier 1: keyword rules
+    const keywordMatch = matchKeywordRules(message);
+    if (keywordMatch) {
+        logger.info(`[PersonaRouter] Tier 1 match: ${keywordMatch.persona} — ${keywordMatch.reasoning}`);
+        return keywordMatch;
+    }
+
+    // Tier 2: LLM micro-classification
+    logger.info('[PersonaRouter] No keyword match, falling back to LLM classification');
+    const llmMatch = await classifyWithLLM(message);
+    logger.info(`[PersonaRouter] Tier 2 result: ${llmMatch.persona} — ${llmMatch.reasoning}`);
+    return llmMatch;
+}
+
+/**
+ * Get all available personas with metadata (for GET /api/v1/ai/personas).
+ */
+export function getAvailablePersonas() {
+    const personas = PERSONA_RULES.map(rule => ({
+        persona: rule.persona,
+        displayName: rule.displayName,
+        description: rule.description,
+        autoSelectable: true,
+    }));
+
+    // Add the default persona
+    personas.push({
+        persona: 'SENIOR_ENGINEER',
+        displayName: 'Senior Engineer',
+        description: 'General implementation, operational queries, cross-cutting concerns',
+        autoSelectable: true,
+    });
+
+    return personas;
+}

--- a/backend/src/services/ai/index.ts
+++ b/backend/src/services/ai/index.ts
@@ -40,6 +40,10 @@ export { ContextEnrichmentService, EnrichmentInput, EnrichmentResult } from './f
 export { AICache, getCache, closeCache } from './cache';
 export { CostTracker, getCostTracker, UsageRecord } from './cost-tracker';
 
+// Export persona routing
+export { routeToPersona, getAvailablePersonas, PersonaSelection } from './PersonaRouter';
+export { getPersonaInstruction, PERSONA_INSTRUCTIONS, PersonaInstruction } from './PersonaInstructions';
+
 // Export main manager
 export {
   AIManager,

--- a/backend/src/services/ai/tools/types.ts
+++ b/backend/src/services/ai/tools/types.ts
@@ -111,6 +111,7 @@ export function hasRequiredRole(userRole: string, requiredRole: string): boolean
  */
 export type SSEEventType =
     | 'thinking'       // LLM is reasoning
+    | 'persona_selected' // Virtual team persona routed for this query
     | 'tool_start'     // About to call a tool
     | 'tool_result'    // Tool returned a result
     | 'confirmation_request'  // Write-tool needs user approval

--- a/frontend/src/components/AICopilot/AICopilot.tsx
+++ b/frontend/src/components/AICopilot/AICopilot.tsx
@@ -12,10 +12,11 @@
  */
 
 import { useRef, useEffect } from 'react';
-import { Box, Typography, IconButton } from '@mui/material';
+import { Box, Typography, IconButton, Chip } from '@mui/material';
 import {
     AutoAwesome as SparkleIcon,
     DeleteOutline as ClearIcon,
+    Person as PersonIcon,
 } from '@mui/icons-material';
 import { useAICopilot, ChatMessage } from '../../hooks/useAICopilot';
 import { useAuth } from '../../hooks/useAuth';
@@ -86,7 +87,7 @@ function ConfirmationPreview({ msg, onConfirm, onDeny, userRole }: {
 
 export default function AICopilot() {
     const {
-        messages, isStreaming,
+        messages, isStreaming, activePersona,
         sendMessage, confirmAction, clearMessages,
         sendActionPrompt,
     } = useAICopilot();
@@ -98,7 +99,7 @@ export default function AICopilot() {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }, [messages, isStreaming]);
 
-    const renderMessage = (msg: ChatMessage) => {
+    const renderMessage = (msg: ChatMessage, index: number) => {
         switch (msg.role) {
             case 'user':
                 return <UserMessage key={msg.id} content={msg.content} />;
@@ -111,8 +112,32 @@ export default function AICopilot() {
                     </Box>
                 );
 
-            case 'thinking':
-                return <ThinkingIndicator key={msg.id} text={msg.content || 'Thinking'} />;
+            case 'thinking': {
+                // Show persona badge on first thinking indicator per exchange
+                const prevMsg = index > 0 ? messages[index - 1] : null;
+                const isFirst = !prevMsg || prevMsg.role === 'user';
+                return (
+                    <Box key={msg.id}>
+                        {isFirst && activePersona && (
+                            <Box sx={{ textAlign: 'center', mb: 0.5 }}>
+                                <Chip
+                                    icon={<PersonIcon sx={{ fontSize: 14 }} />}
+                                    label={`${activePersona.displayName} is handling this`}
+                                    size="small"
+                                    color="primary"
+                                    variant="outlined"
+                                    sx={{
+                                        fontSize: '0.7rem',
+                                        height: 24,
+                                        '& .MuiChip-icon': { ml: 0.5 },
+                                    }}
+                                />
+                            </Box>
+                        )}
+                        <ThinkingIndicator text={msg.content || 'Thinking'} />
+                    </Box>
+                );
+            }
 
             case 'tool_start':
                 return (
@@ -204,7 +229,7 @@ export default function AICopilot() {
                     <EmptyState onSend={sendMessage} />
                 )}
 
-                {messages.map(renderMessage)}
+                {messages.map((msg, idx) => renderMessage(msg, idx))}
                 <div ref={bottomRef} />
             </Box>
 

--- a/frontend/src/hooks/useAICopilot.ts
+++ b/frontend/src/hooks/useAICopilot.ts
@@ -11,6 +11,14 @@ export type MessageRole = 'user' | 'assistant' | 'tool_start' | 'tool_result' | 
 
 export type CardState = 'idle' | 'action_pending' | 'updated';
 
+/** Virtual team persona selected by the PersonaRouter */
+export interface PersonaInfo {
+    persona: string;
+    displayName: string;
+    confidence: number;
+    reasoning: string;
+}
+
 export interface ChatMessage {
     id: string;
     role: MessageRole;
@@ -33,6 +41,8 @@ export interface UseAICopilotReturn {
     messages: ChatMessage[];
     isStreaming: boolean;
     error: string | null;
+    /** Currently active persona for the latest query */
+    activePersona: PersonaInfo | null;
     sendMessage: (message: string) => void;
     confirmAction: (actionId: string, approved: boolean) => Promise<void>;
     clearMessages: () => void;
@@ -58,6 +68,7 @@ export function useAICopilot(): UseAICopilotReturn {
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [isStreaming, setIsStreaming] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [activePersona, setActivePersona] = useState<PersonaInfo | null>(null);
     const sessionIdRef = useRef<string>(generateSessionId());
     const abortRef = useRef<AbortController | null>(null);
 
@@ -139,6 +150,17 @@ export function useAICopilot(): UseAICopilotReturn {
                         const event = JSON.parse(jsonStr);
 
                         switch (event.type) {
+                            case 'persona_selected': {
+                                const personaData = JSON.parse(event.data);
+                                setActivePersona({
+                                    persona: personaData.persona,
+                                    displayName: personaData.displayName,
+                                    confidence: personaData.confidence,
+                                    reasoning: personaData.reasoning,
+                                });
+                                break;
+                            }
+
                             case 'thinking':
                                 setMessages(prev => [...prev, {
                                     id: generateId(),
@@ -351,10 +373,11 @@ export function useAICopilot(): UseAICopilotReturn {
         setMessages([]);
         setError(null);
         setIsStreaming(false);
+        setActivePersona(null);
     }, []);
 
     return {
-        messages, isStreaming, error,
+        messages, isStreaming, error, activePersona,
         sendMessage, confirmAction, clearMessages,
         updateMessage, sendActionPrompt,
     };


### PR DESCRIPTION
Commit: 0f3876c on claude/consolidate-config-ai-services-eoQHg
New files
	∙	PersonaRouter.ts — Two-tier query classifier (keyword rules + LLM fallback) that routes to 9 personas following the TEAM_SELECTION.md priority rubric
	∙	PersonaInstructions.ts — Condensed ~200-token system prompt addons per persona with display names, emojis, and preferred tools
Modified files
	∙	AIChatService.ts — buildSystemPrompt() now accepts a persona and injects its instructions; handleChatStream() routes the query and emits persona_selected SSE before the ReAct loop
	∙	tools/types.ts — Added persona_selected to SSEEventType
	∙	routes/ai/index.ts — Added GET /api/v1/ai/personas endpoint
	∙	services/ai/index.ts — Barrel exports for persona modules
	∙	All 3 Prisma schemas — activePersona on ChatSession, persona on ChatMessage
	∙	useAICopilot.ts — Handles persona_selected SSE event, exposes activePersona state
	∙	AICopilot.tsx — Renders a persona badge chip above the first thinking indicator per exchange
Verification
	∙	All 60 tests pass
	∙	Schema parity validation passes (20 shared models, 1 allowlisted)
	∙	TypeScript compiles clean (backend + frontend)