### PR TITLE
Sprint 5.2: Reconcile schema field drift (40 to 0)

### DIFF
--- a/backend/prisma/schema.dev.prisma
+++ b/backend/prisma/schema.dev.prisma
@@ -33,24 +33,30 @@ model TestRun {
   userId     String?
   name       String
   status     String    @default("PENDING") // PENDING | RUNNING | PASSED | FAILED | SKIPPED | FLAKY
-  branch     String?
-  commit     String?
   startedAt  DateTime? @default(now())
   completedAt DateTime?
   duration   Int?
-  // results string removed in favor of relation to match prod
-  error      String?
+  totalTests Int       @default(0)
+  passed     Int       @default(0)
+  failed     Int       @default(0)
+  skipped    Int       @default(0)
+  flaky      Int       @default(0)
+  branch     String?
+  commit     String?
+  buildNumber String?
+  metadata   String?   // JSON string (SQLite)
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
-  // Relations
-  pipeline   Pipeline  @relation(fields: [pipelineId], references: [id])
-  user       User?     @relation(fields: [userId], references: [id])
-  results    TestResult[]
+  pipeline      Pipeline       @relation(fields: [pipelineId], references: [id], onDelete: Cascade)
+  user          User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  results       TestResult[]
+  notifications Notification[]
 
   @@index([pipelineId])
   @@index([userId])
   @@index([status])
+  @@index([startedAt])
 }
 
 model FailureArchive {
@@ -115,18 +121,21 @@ model FailureComment {
   @@index([userId])
 }
 
-// Simplified AI usage tracking for demo
 model AIUsage {
-  id              String   @id @default(uuid())
-  provider        String   // "anthropic", "openai", "google"
-  model           String
-  tokens          Int
-  cost            Float
-  cacheHit        Boolean  @default(false)
-  responseTimeMs  Int
-  createdAt       DateTime @default(now())
+  id               String   @id @default(uuid())
+  provider         String
+  model            String
+  feature          String
+  promptTokens     Int
+  completionTokens Int
+  totalTokens      Int
+  cost             Float
+  userId           String?
+  metadata         String?   // JSON string (SQLite)
+  createdAt        DateTime  @default(now())
 
   @@index([provider])
+  @@index([feature])
   @@index([createdAt])
 }
 
@@ -163,24 +172,22 @@ model JiraIssue {
   @@index([projectKey])
 }
 
-// Pipeline model
 model Pipeline {
   id          String     @id @default(uuid())
   name        String
-  type        String     @default("CUSTOM") // JENKINS | GITHUB_ACTIONS | CUSTOM
-  status      String     @default("PENDING") // PENDING | RUNNING | SUCCESS | FAILURE | CANCELLED | TIMEOUT
-  config      String     // JSON stored as string
-  description String?
+  type        String     @default("CUSTOM") // GITHUB_ACTIONS | JENKINS | CUSTOM
+  repository  String?
+  branch      String?
+  config      String?    // JSON string (SQLite)
+  enabled     Boolean    @default(true)
+  lastRunAt   DateTime?
   teamId      String?
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
-  // Relations
   testRuns    TestRun[]
   team        Team?      @relation(fields: [teamId], references: [id])
 
-  @@index([type])
-  @@index([status])
   @@index([teamId])
 }
 
@@ -204,64 +211,70 @@ model FailurePattern {
   @@index([isActive])
 }
 
-// Added during Refactor for missing models
-
 model Notification {
   id        String   @id @default(uuid())
   userId    String
-  type      String
+  testRunId String?
+  type      String   // TEST_FAILED | TEST_PASSED | PIPELINE_FAILED | PIPELINE_PASSED | SYSTEM
   title     String
   message   String
   read      Boolean  @default(false)
-  data      String?  // JSON
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
-  user      User     @relation(fields: [userId], references: [id])
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  testRun   TestRun? @relation(fields: [testRunId], references: [id], onDelete: Cascade)
+
   @@index([userId])
+  @@index([read])
 }
 
 model TestRailRun {
-  id            String   @id @default(uuid())
-  testRailRunId Int      @unique
+  id            String    @id @default(uuid())
+  testRailRunId Int       @unique
   projectId     Int
   suiteId       Int?
   name          String
-  testRunId     String?  // nullable and not unique in prod?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  description   String?
+  testRunId     String?
+  metadata      String?   // JSON string (SQLite)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([projectId])
 }
 
 model ConfluencePage {
-  id          String   @id @default(uuid())
-  pageId      String
-  title       String
-  spaceKey    String
-  version     Int?
-  url         String
-  testRunId   String?
-  type        String?
-  sourceId    String?
-  metadata    String?  // JSON string
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id               String    @id @default(uuid())
+  pageId           String    @unique
+  spaceKey         String
+  title            String
+  url              String
+  failureArchiveId String?
+  publishedBy      String?
+  metadata         String?   // JSON string (SQLite)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  @@index([spaceKey])
 }
 
 model TestResult {
   id          String   @id @default(uuid())
   testRunId   String
-  testName    String
-  testCaseId  String?
-  message     String?
-  status      String
+  name        String
+  className   String?
+  status      String   // PENDING | RUNNING | PASSED | FAILED | SKIPPED | FLAKY
   duration    Int?
   error       String?
   stackTrace  String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
-  
+
   testRun     TestRun  @relation(fields: [testRunId], references: [id], onDelete: Cascade)
+
   @@index([testRunId])
+  @@index([status])
 }
 
 // ─── AI Copilot Chat Persistence ───
@@ -374,6 +387,26 @@ model DashboardConfig {
 
   @@index([teamId])
   @@index([userId])
+}
+
+// ─── Shareable Analysis Links ───
+
+model SharedAnalysis {
+  id          String   @id @default(uuid())
+  token       String   @unique
+  userId      String
+  sessionId   String?
+  title       String
+  content     String
+  persona     String?
+  toolSummary String?   // JSON string (SQLite)
+  expiresAt   DateTime
+  viewCount   Int      @default(0)
+  createdAt   DateTime @default(now())
+
+  @@index([token])
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 // ─── Multi-Channel User Mapping ───

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,24 +33,30 @@ model TestRun {
   userId     String?
   name       String
   status     String    @default("PENDING") // PENDING | RUNNING | PASSED | FAILED | SKIPPED | FLAKY
-  branch     String?
-  commit     String?
   startedAt  DateTime? @default(now())
   completedAt DateTime?
   duration   Int?
-  // results string removed in favor of relation to match prod
-  error      String?
+  totalTests Int       @default(0)
+  passed     Int       @default(0)
+  failed     Int       @default(0)
+  skipped    Int       @default(0)
+  flaky      Int       @default(0)
+  branch     String?
+  commit     String?
+  buildNumber String?
+  metadata   String?   // JSON string (SQLite)
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
-  // Relations
-  pipeline   Pipeline  @relation(fields: [pipelineId], references: [id])
-  user       User?     @relation(fields: [userId], references: [id])
-  results    TestResult[]
+  pipeline      Pipeline       @relation(fields: [pipelineId], references: [id], onDelete: Cascade)
+  user          User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  results       TestResult[]
+  notifications Notification[]
 
   @@index([pipelineId])
   @@index([userId])
   @@index([status])
+  @@index([startedAt])
 }
 
 model FailureArchive {
@@ -115,18 +121,21 @@ model FailureComment {
   @@index([userId])
 }
 
-// Simplified AI usage tracking for demo
 model AIUsage {
-  id              String   @id @default(uuid())
-  provider        String   // "anthropic", "openai", "google"
-  model           String
-  tokens          Int
-  cost            Float
-  cacheHit        Boolean  @default(false)
-  responseTimeMs  Int
-  createdAt       DateTime @default(now())
+  id               String   @id @default(uuid())
+  provider         String
+  model            String
+  feature          String
+  promptTokens     Int
+  completionTokens Int
+  totalTokens      Int
+  cost             Float
+  userId           String?
+  metadata         String?   // JSON string (SQLite)
+  createdAt        DateTime  @default(now())
 
   @@index([provider])
+  @@index([feature])
   @@index([createdAt])
 }
 
@@ -163,24 +172,22 @@ model JiraIssue {
   @@index([projectKey])
 }
 
-// Pipeline model
 model Pipeline {
   id          String     @id @default(uuid())
   name        String
-  type        String     @default("CUSTOM") // JENKINS | GITHUB_ACTIONS | CUSTOM
-  status      String     @default("PENDING") // PENDING | RUNNING | SUCCESS | FAILURE | CANCELLED | TIMEOUT
-  config      String     // JSON stored as string
-  description String?
+  type        String     @default("CUSTOM") // GITHUB_ACTIONS | JENKINS | CUSTOM
+  repository  String?
+  branch      String?
+  config      String?    // JSON string (SQLite)
+  enabled     Boolean    @default(true)
+  lastRunAt   DateTime?
   teamId      String?
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
-  // Relations
   testRuns    TestRun[]
   team        Team?      @relation(fields: [teamId], references: [id])
 
-  @@index([type])
-  @@index([status])
   @@index([teamId])
 }
 
@@ -204,64 +211,70 @@ model FailurePattern {
   @@index([isActive])
 }
 
-// Added during Refactor for missing models
-
 model Notification {
   id        String   @id @default(uuid())
   userId    String
-  type      String
+  testRunId String?
+  type      String   // TEST_FAILED | TEST_PASSED | PIPELINE_FAILED | PIPELINE_PASSED | SYSTEM
   title     String
   message   String
   read      Boolean  @default(false)
-  data      String?  // JSON
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
-  user      User     @relation(fields: [userId], references: [id])
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  testRun   TestRun? @relation(fields: [testRunId], references: [id], onDelete: Cascade)
+
   @@index([userId])
+  @@index([read])
 }
 
 model TestRailRun {
-  id            String   @id @default(uuid())
-  testRailRunId Int      @unique
+  id            String    @id @default(uuid())
+  testRailRunId Int       @unique
   projectId     Int
   suiteId       Int?
   name          String
-  testRunId     String?  // nullable and not unique in prod?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  description   String?
+  testRunId     String?
+  metadata      String?   // JSON string (SQLite)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([projectId])
 }
 
 model ConfluencePage {
-  id          String   @id @default(uuid())
-  pageId      String
-  title       String
-  spaceKey    String
-  version     Int?
-  url         String
-  testRunId   String?
-  type        String?
-  sourceId    String?
-  metadata    String?  // JSON string
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id               String    @id @default(uuid())
+  pageId           String    @unique
+  spaceKey         String
+  title            String
+  url              String
+  failureArchiveId String?
+  publishedBy      String?
+  metadata         String?   // JSON string (SQLite)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  @@index([spaceKey])
 }
 
 model TestResult {
   id          String   @id @default(uuid())
   testRunId   String
-  testName    String
-  testCaseId  String?
-  message     String?
-  status      String
+  name        String
+  className   String?
+  status      String   // PENDING | RUNNING | PASSED | FAILED | SKIPPED | FLAKY
   duration    Int?
   error       String?
   stackTrace  String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
-  
+
   testRun     TestRun  @relation(fields: [testRunId], references: [id], onDelete: Cascade)
+
   @@index([testRunId])
+  @@index([status])
 }
 
 // ─── AI Copilot Chat Persistence ───
@@ -376,6 +389,26 @@ model DashboardConfig {
   @@index([userId])
 }
 
+// ─── Shareable Analysis Links ───
+
+model SharedAnalysis {
+  id          String   @id @default(uuid())
+  token       String   @unique
+  userId      String
+  sessionId   String?
+  title       String
+  content     String
+  persona     String?
+  toolSummary String?   // JSON string (SQLite)
+  expiresAt   DateTime
+  viewCount   Int      @default(0)
+  createdAt   DateTime @default(now())
+
+  @@index([token])
+  @@index([userId])
+  @@index([expiresAt])
+}
+
 // ─── Multi-Channel User Mapping ───
 
 model ChannelUserMapping {
@@ -388,24 +421,4 @@ model ChannelUserMapping {
 
   @@unique([channel, externalId])
   @@index([userId])
-}
-
-// ─── Shared Analysis Links ───
-
-model SharedAnalysis {
-  id          String   @id @default(uuid())
-  token       String   @unique  // URL-safe token for share links
-  userId      String             // Who shared it
-  sessionId   String?            // Optional link to chat session
-  title       String
-  content     String             // Markdown of the AI analysis
-  persona     String?            // Which persona generated it
-  toolSummary String?            // JSON: tool calls summary
-  expiresAt   DateTime           // Default 7 days from creation
-  viewCount   Int      @default(0)
-  createdAt   DateTime @default(now())
-
-  @@index([token])
-  @@index([userId])
-  @@index([expiresAt])
 }

--- a/backend/prisma/schema.production.prisma
+++ b/backend/prisma/schema.production.prisma
@@ -426,6 +426,27 @@ model DashboardConfig {
   @@map("dashboard_configs")
 }
 
+// ─── Shareable Analysis Links ───
+
+model SharedAnalysis {
+  id          String   @id @default(uuid()) @db.Uuid
+  token       String   @unique
+  userId      String
+  sessionId   String?
+  title       String
+  content     String
+  persona     String?
+  toolSummary String?  // JSON
+  expiresAt   DateTime
+  viewCount   Int      @default(0)
+  createdAt   DateTime @default(now())
+
+  @@index([token])
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("shared_analyses")
+}
+
 // ─── Multi-Channel User Mapping ───
 
 model ChannelUserMapping {

--- a/backend/prisma/seed.dev.js
+++ b/backend/prisma/seed.dev.js
@@ -156,10 +156,10 @@ const PIPELINE_TEMPLATES = [
 ];
 
 const AI_PROVIDERS = [
-  { name: 'anthropic', model: 'claude-opus-4-6', avgTokens: 1200, avgCost: 0.108, avgTime: 1800 },
-  { name: 'openai', model: 'gpt-4.1', avgTokens: 1500, avgCost: 0.06, avgTime: 2100 },
-  { name: 'google', model: 'gemini-3.0-flash', avgTokens: 1100, avgCost: 0.000825, avgTime: 1200 },
-  { name: 'openrouter', model: 'meta-llama/llama-4-maverick', avgTokens: 1300, avgCost: 0.003, avgTime: 1500 },
+  { name: 'anthropic', model: 'claude-opus-4-6', avgPromptTokens: 800, avgCompletionTokens: 400, avgCost: 0.108 },
+  { name: 'openai', model: 'gpt-4.1', avgPromptTokens: 1000, avgCompletionTokens: 500, avgCost: 0.06 },
+  { name: 'google', model: 'gemini-3.0-flash', avgPromptTokens: 700, avgCompletionTokens: 400, avgCost: 0.000825 },
+  { name: 'openrouter', model: 'meta-llama/llama-4-maverick', avgPromptTokens: 900, avgCompletionTokens: 400, avgCost: 0.003 },
 ];
 
 const NOTIFICATION_TEMPLATES = [
@@ -205,15 +205,13 @@ async function seedDevelopmentData() {
       data: {
         name: template.name,
         type: template.type,
-        status: Math.random() > 0.7 ? 'PENDING' : Math.random() > 0.5 ? 'RUNNING' : 'COMPLETED',
+        repository: `testops-${template.name.toLowerCase().replace(/\s+/g, '-')}`,
+        branch: 'main',
         config: JSON.stringify({
-          repo: `testops-${template.name.toLowerCase().replace(/\s+/g, '-')}`,
-          branch: 'main',
           triggers: ['push', 'pull_request'],
           notifications: { email: true, slack: true }
         }),
-        // userId: admin.id, // Removed for Prod schema alignment
-        description: template.description,
+        enabled: true,
       },
     });
     pipelines.push(pipeline);
@@ -262,7 +260,8 @@ async function seedDevelopmentData() {
     const isFlakyRun = i % 3 === 0; // Every 3rd run fails
     testResultPayloads.push({
       testRunId: runId,
-      testName: 'PaymentProcessor.processCheckout',
+      name: 'PaymentProcessor.processCheckout',
+      className: 'PaymentProcessor',
       status: isFlakyRun ? 'FAILED' : 'PASSED',
       duration: 100 + Math.random() * 50,
       createdAt: endTime
@@ -271,7 +270,8 @@ async function seedDevelopmentData() {
     // 2. A guaranteed Stable Test
     testResultPayloads.push({
       testRunId: runId,
-      testName: 'AuthService.login',
+      name: 'AuthService.login',
+      className: 'AuthService',
       status: 'PASSED',
       duration: 50 + Math.random() * 20,
       createdAt: endTime
@@ -326,16 +326,20 @@ async function seedDevelopmentData() {
   for (let day = 0; day < 60; day++) {
     for (const provider of AI_PROVIDERS) {
       const callsPerDay = Math.floor(Math.random() * 120) + 40;
+      const features = ['rca', 'categorization', 'log-summary', 'chat', 'prediction'];
       for (let call = 0; call < callsPerDay; call++) {
-        const cacheHit = Math.random() > 0.35; // 65% cache hit rate
+        const isCached = Math.random() > 0.35; // 65% cache hit rate
+        const promptTokens = isCached ? 0 : provider.avgPromptTokens + Math.floor(Math.random() * 200) - 100;
+        const completionTokens = isCached ? 0 : provider.avgCompletionTokens + Math.floor(Math.random() * 200) - 100;
 
         currentBatch.push({
           provider: provider.name,
           model: provider.model,
-          tokens: cacheHit ? 0 : provider.avgTokens + Math.floor(Math.random() * 400) - 200,
-          cost: cacheHit ? 0 : provider.avgCost * (0.7 + Math.random() * 0.6),
-          cacheHit,
-          responseTimeMs: cacheHit ? 50 + Math.floor(Math.random() * 150) : provider.avgTime + Math.floor(Math.random() * 800) - 400,
+          feature: features[Math.floor(Math.random() * features.length)],
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+          cost: isCached ? 0 : provider.avgCost * (0.7 + Math.random() * 0.6),
           createdAt: new Date(now - day * 86400000 - Math.random() * 86400000),
         });
 

--- a/backend/src/routes/notification.routes.ts
+++ b/backend/src/routes/notification.routes.ts
@@ -12,14 +12,13 @@ const notificationController = new NotificationController();
  * Map Prisma Notification to frontend contract.
  * DB uses `read`; frontend expects `delivered` + `timestamp`.
  */
-function toNotificationDTO(n: { id: string; type: string; title: string; message: string; read: boolean; data: string | null; createdAt: Date }) {
-  const data = n.data ? JSON.parse(n.data) : {};
+function toNotificationDTO(n: { id: string; type: string; title: string; message: string; read: boolean; testRunId: string | null; createdAt: Date }) {
   return {
     id: n.id,
-    testRunId: data.testRunId || '',
-    pipelineName: data.pipelineName || n.title,
+    testRunId: n.testRunId || '',
+    pipelineName: n.title,
     type: n.type,
-    status: data.status || n.type.toUpperCase(),
+    status: n.type.toUpperCase(),
     message: n.message,
     timestamp: n.createdAt.toISOString(),
     delivered: n.read,

--- a/backend/src/routes/testRun.routes.ts
+++ b/backend/src/routes/testRun.routes.ts
@@ -92,7 +92,10 @@ router.get(
       'FLAKY': 'flaky'
     };
 
-    const error = testRun.error || null;
+    // Collect error messages from failed test results
+    const errorLogs = testRun.results
+      ?.filter((r: { status: string; error?: string | null }) => r.status === 'FAILED' && r.error)
+      .map((r: { error?: string | null }) => r.error!) || [];
 
     res.status(200).json({
       id: testRun.id,
@@ -103,7 +106,7 @@ router.get(
       endTime: testRun.completedAt?.toISOString() || testRun.createdAt.toISOString(),
       duration: testRun.duration || 0,
       errorCount: failed,
-      errorLogs: error ? [error] : [],
+      errorLogs,
       screenshots: []
     });
   })

--- a/backend/src/services/test/FlakyTestService.ts
+++ b/backend/src/services/test/FlakyTestService.ts
@@ -38,20 +38,16 @@ export class FlakyTestService {
      * This is a heavy operation, meant for background jobs.
      */
     async analyzeAllTests(): Promise<FlakyStats[]> {
-        // Group runs by test name
-        // Since TestResult has testName, we should query TestResults joined with TestRun
-        // However, Prisma groupBy on relations is tricky.
-        // Let's get distinct test names first.
-
+        // Get distinct test names from TestResult
         const testNames = await prisma.testResult.findMany({
-            distinct: ['testName'],
-            select: { testName: true }
+            distinct: ['name'],
+            select: { name: true }
         });
 
         logger.info(`[FlakyTestService] Analyzing ${testNames.length} tests...`);
 
         const results: FlakyStats[] = [];
-        for (const { testName } of testNames) {
+        for (const { name: testName } of testNames) {
             const stats = await this.analyzeTest(testName);
             if (stats.severity !== 'STABLE') {
                 results.push(stats);
@@ -67,7 +63,7 @@ export class FlakyTestService {
     async analyzeTest(testName: string): Promise<FlakyStats> {
         // Fetch last N results for this test, ordered by time
         const history = await prisma.testResult.findMany({
-            where: { testName },
+            where: { name: testName },
             orderBy: { createdAt: 'desc' },
             take: this.WINDOW_SIZE,
             include: { testRun: true }


### PR DESCRIPTION
## Summary
- Aligned dev schema (SQLite) to production schema (PostgreSQL) across 7 models: TestRun, TestResult, AIUsage, Pipeline, Notification, ConfluencePage, TestRailRun
- Added SharedAnalysis model to both dev and prod schemas (was missing from both)
- Updated FlakyTestService, notification routes, testRun routes, and seed data to match new field names

## Verification
- `tsc --noEmit`: clean
- `jest`: 60/60 pass
- `eslint`: clean
- `validate-schema.js`: **zero field drift** (22 shared models, all fields match)