### PR TITLE
ci: Sprint 5.4 — enable --strict-fields in CI schema validation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Schema parity check (model + field level)
       working-directory: .
-      run: node scripts/validate-schema.js
+      run: node scripts/validate-schema.js --strict-fields
 
     - name: Typecheck with dev schema (SQLite / demo mode)
       run: |

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -181,7 +181,7 @@ jobs:
           echo "✅ Prisma schemas are correctly configured"
 
       - name: Check schema model parity
-        run: node scripts/validate-schema.js
+        run: node scripts/validate-schema.js --strict-fields
 
       - name: Check required files exist
         run: |


### PR DESCRIPTION
Added --strict-fields to backend-ci.yml and installation-test.yml