### PR TITLE
feat(resilience): add circuit breaker + retry + timeout for external …

### DIFF
--- a/backend/src/controllers/health.controller.ts
+++ b/backend/src/controllers/health.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { prisma } from '../lib/prisma';
 import Redis from 'ioredis';
+import { getAllCircuitBreakerStatuses, type CircuitBreakerStatus } from '../lib/resilience';
 
 interface HealthCheckResult {
   status: 'healthy' | 'degraded' | 'unhealthy';
@@ -13,6 +14,7 @@ interface HealthCheckResult {
     weaviate?: ServiceStatus;
     ai?: ServiceStatus;
   };
+  circuitBreakers: CircuitBreakerStatus[];
   environment: {
     nodeEnv: string;
     nodeVersion: string;
@@ -65,6 +67,7 @@ export async function healthCheckFull(req: Request, res: Response): Promise<void
       weaviate: await checkWeaviate(),
       ai: await checkAI()
     },
+    circuitBreakers: getAllCircuitBreakerStatuses(),
     environment: {
       nodeEnv: process.env.NODE_ENV || 'development',
       nodeVersion: process.version,
@@ -76,10 +79,11 @@ export async function healthCheckFull(req: Request, res: Response): Promise<void
   const services = Object.values(result.services);
   const hasDown = services.some(s => s?.status === 'down');
   const hasDegraded = services.some(s => s?.status === 'degraded');
+  const hasOpenBreaker = result.circuitBreakers.some(cb => cb.state === 'OPEN');
 
   if (hasDown) {
     result.status = 'unhealthy';
-  } else if (hasDegraded) {
+  } else if (hasDegraded || hasOpenBreaker) {
     result.status = 'degraded';
   }
 

--- a/backend/src/lib/__tests__/resilience.test.ts
+++ b/backend/src/lib/__tests__/resilience.test.ts
@@ -1,0 +1,389 @@
+import {
+  CircuitBreaker,
+  CircuitOpenError,
+  TimeoutError,
+  withRetry,
+  withTimeout,
+  withResilience,
+  circuitBreakers,
+  getAllCircuitBreakerStatuses,
+} from '../resilience';
+
+// Silence logger during tests
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ─── CircuitBreaker ──────────────────────────────────────────────────
+
+describe('CircuitBreaker', () => {
+  let breaker: CircuitBreaker;
+
+  beforeEach(() => {
+    breaker = new CircuitBreaker('test-service', {
+      failureThreshold: 3,
+      resetTimeoutMs: 100, // Short for fast tests
+      halfOpenSuccessThreshold: 1,
+    });
+  });
+
+  it('starts in CLOSED state', () => {
+    expect(breaker.getStatus().state).toBe('CLOSED');
+    expect(breaker.getStatus().failures).toBe(0);
+  });
+
+  it('allows calls through when CLOSED', async () => {
+    const result = await breaker.execute(() => Promise.resolve('ok'));
+    expect(result).toBe('ok');
+  });
+
+  it('resets failure count on success', async () => {
+    // 2 failures (below threshold)
+    for (let i = 0; i < 2; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow('fail');
+    }
+    expect(breaker.getStatus().failures).toBe(2);
+
+    // Success resets
+    await breaker.execute(() => Promise.resolve('ok'));
+    expect(breaker.getStatus().failures).toBe(0);
+  });
+
+  it('transitions to OPEN after reaching failure threshold', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+
+    expect(breaker.getStatus().state).toBe('OPEN');
+    expect(breaker.getStatus().failures).toBe(3);
+  });
+
+  it('rejects calls immediately when OPEN', async () => {
+    // Trip the breaker
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+
+    // Next call should throw CircuitOpenError without calling the fn
+    const fn = jest.fn();
+    await expect(breaker.execute(fn)).rejects.toThrow(CircuitOpenError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('CircuitOpenError contains service name and retry info', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+
+    try {
+      await breaker.execute(() => Promise.resolve('ok'));
+    } catch (error) {
+      expect(error).toBeInstanceOf(CircuitOpenError);
+      expect((error as CircuitOpenError).serviceName).toBe('test-service');
+      expect((error as CircuitOpenError).retryAfterMs).toBeGreaterThan(0);
+    }
+  });
+
+  it('transitions to HALF_OPEN after reset timeout', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+    expect(breaker.getStatus().state).toBe('OPEN');
+
+    // Wait for reset timeout
+    await sleep(150);
+
+    // Next call should be attempted (HALF_OPEN)
+    const result = await breaker.execute(() => Promise.resolve('recovered'));
+    expect(result).toBe('recovered');
+    expect(breaker.getStatus().state).toBe('CLOSED');
+  });
+
+  it('re-opens on failure in HALF_OPEN state', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+
+    // Wait for reset
+    await sleep(150);
+
+    // Fail again in HALF_OPEN
+    await expect(breaker.execute(() => Promise.reject(new Error('still broken')))).rejects.toThrow();
+    expect(breaker.getStatus().state).toBe('OPEN');
+  });
+
+  it('reset() restores CLOSED state', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+    expect(breaker.getStatus().state).toBe('OPEN');
+
+    breaker.reset();
+    expect(breaker.getStatus().state).toBe('CLOSED');
+    expect(breaker.getStatus().failures).toBe(0);
+  });
+
+  it('getStatus() returns complete status', async () => {
+    const status = breaker.getStatus();
+    expect(status).toEqual({
+      name: 'test-service',
+      state: 'CLOSED',
+      failures: 0,
+      lastFailureTime: null,
+      nextRetryTime: null,
+    });
+  });
+
+  it('getStatus() includes lastFailureTime when circuit is OPEN', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow();
+    }
+
+    const status = breaker.getStatus();
+    expect(status.state).toBe('OPEN');
+    expect(status.lastFailureTime).not.toBeNull();
+    expect(status.nextRetryTime).not.toBeNull();
+  });
+});
+
+// ─── withRetry ───────────────────────────────────────────────────────
+
+describe('withRetry', () => {
+  it('returns result on first try success', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await withRetry(fn, { maxRetries: 2, baseDelayMs: 10 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on retryable error and succeeds', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(makeNetworkError('ECONNRESET'))
+      .mockResolvedValue('recovered');
+
+    const result = await withRetry(fn, { maxRetries: 2, baseDelayMs: 10 });
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries up to maxRetries times', async () => {
+    const fn = jest.fn().mockRejectedValue(makeNetworkError('ECONNREFUSED'));
+
+    await expect(withRetry(fn, { maxRetries: 3, baseDelayMs: 10 })).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('Validation failed'));
+
+    await expect(withRetry(fn, { maxRetries: 3, baseDelayMs: 10 })).rejects.toThrow('Validation failed');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 5xx HTTP status', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValue('ok');
+
+    const result = await withRetry(fn, { maxRetries: 2, baseDelayMs: 10 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 429 rate limit', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce({ status: 429 })
+      .mockResolvedValue('ok');
+
+    const result = await withRetry(fn, { maxRetries: 2, baseDelayMs: 10 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 4xx (non-429) status', async () => {
+    const fn = jest.fn().mockRejectedValue({ status: 404 });
+
+    await expect(withRetry(fn, { maxRetries: 3, baseDelayMs: 10 })).rejects.toEqual({ status: 404 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports custom shouldRetry predicate', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('retryable'))
+      .mockResolvedValue('ok');
+
+    const result = await withRetry(fn, {
+      maxRetries: 2,
+      baseDelayMs: 10,
+      shouldRetry: (e) => e instanceof Error && e.message === 'retryable',
+    });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── withTimeout ─────────────────────────────────────────────────────
+
+describe('withTimeout', () => {
+  it('returns result when function completes before timeout', async () => {
+    const result = await withTimeout(
+      () => Promise.resolve('fast'),
+      1000,
+      'test-op',
+    );
+    expect(result).toBe('fast');
+  });
+
+  it('throws TimeoutError when function exceeds timeout', async () => {
+    await expect(
+      withTimeout(
+        () => sleep(500),
+        50,
+        'slow-op',
+      ),
+    ).rejects.toThrow(TimeoutError);
+  });
+
+  it('TimeoutError contains operation name and timeout duration', async () => {
+    try {
+      await withTimeout(() => sleep(500), 50, 'my-operation');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TimeoutError);
+      expect((error as TimeoutError).message).toContain('my-operation');
+      expect((error as TimeoutError).timeoutMs).toBe(50);
+    }
+  });
+
+  it('propagates errors from the wrapped function', async () => {
+    await expect(
+      withTimeout(
+        () => Promise.reject(new Error('inner error')),
+        1000,
+      ),
+    ).rejects.toThrow('inner error');
+  });
+});
+
+// ─── withResilience (composed) ───────────────────────────────────────
+
+describe('withResilience', () => {
+  let breaker: CircuitBreaker;
+
+  beforeEach(() => {
+    breaker = new CircuitBreaker('composed-test', {
+      failureThreshold: 2,
+      resetTimeoutMs: 100,
+    });
+  });
+
+  it('composes circuit breaker + retry + timeout', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(makeNetworkError('ECONNRESET'))
+      .mockResolvedValue('ok');
+
+    const result = await withResilience(fn, {
+      circuitBreaker: breaker,
+      retry: { maxRetries: 2, baseDelayMs: 10 },
+      timeoutMs: 5000,
+      label: 'test-call',
+    });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('works with only circuit breaker', async () => {
+    const result = await withResilience(
+      () => Promise.resolve('ok'),
+      { circuitBreaker: breaker },
+    );
+    expect(result).toBe('ok');
+  });
+
+  it('works with only retry', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(makeNetworkError('ECONNRESET'))
+      .mockResolvedValue('ok');
+
+    const result = await withResilience(fn, {
+      retry: { maxRetries: 1, baseDelayMs: 10 },
+    });
+    expect(result).toBe('ok');
+  });
+
+  it('works with only timeout', async () => {
+    const result = await withResilience(
+      () => Promise.resolve('fast'),
+      { timeoutMs: 1000 },
+    );
+    expect(result).toBe('fast');
+  });
+
+  it('circuit breaker wraps retry (failures during retry count toward breaker)', async () => {
+    const fn = jest.fn().mockRejectedValue(makeNetworkError('ECONNREFUSED'));
+
+    // First call: retries exhaust, failure #1 on circuit
+    await expect(withResilience(fn, {
+      circuitBreaker: breaker,
+      retry: { maxRetries: 1, baseDelayMs: 10 },
+    })).rejects.toThrow();
+
+    // Second call: retries exhaust, failure #2 → circuit opens
+    await expect(withResilience(fn, {
+      circuitBreaker: breaker,
+      retry: { maxRetries: 1, baseDelayMs: 10 },
+    })).rejects.toThrow();
+
+    expect(breaker.getStatus().state).toBe('OPEN');
+  });
+});
+
+// ─── Pre-configured breakers ─────────────────────────────────────────
+
+describe('circuitBreakers', () => {
+  afterEach(() => {
+    // Reset all breakers after each test
+    Object.values(circuitBreakers).forEach(cb => cb.reset());
+  });
+
+  it('has breakers for github, jira, jenkins, confluence', () => {
+    expect(circuitBreakers.github).toBeInstanceOf(CircuitBreaker);
+    expect(circuitBreakers.jira).toBeInstanceOf(CircuitBreaker);
+    expect(circuitBreakers.jenkins).toBeInstanceOf(CircuitBreaker);
+    expect(circuitBreakers.confluence).toBeInstanceOf(CircuitBreaker);
+  });
+
+  it('getAllCircuitBreakerStatuses() returns all breaker states', () => {
+    const statuses = getAllCircuitBreakerStatuses();
+    expect(statuses).toHaveLength(4);
+
+    const names = statuses.map(s => s.name);
+    expect(names).toContain('github');
+    expect(names).toContain('jira');
+    expect(names).toContain('jenkins');
+    expect(names).toContain('confluence');
+
+    statuses.forEach(s => {
+      expect(s.state).toBe('CLOSED');
+      expect(s.failures).toBe(0);
+    });
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function makeNetworkError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`connect ${code}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}

--- a/backend/src/lib/resilience.ts
+++ b/backend/src/lib/resilience.ts
@@ -1,0 +1,341 @@
+/**
+ * Resilience utilities for external service calls.
+ *
+ * Provides circuit breaker, retry with exponential backoff, and timeout
+ * enforcement for integration points (GitHub, Jira, Jenkins, Confluence).
+ *
+ * Usage:
+ *   const breaker = new CircuitBreaker('github', { failureThreshold: 5 });
+ *   const result = await breaker.execute(() => octokit.repos.get(...));
+ */
+
+import { logger } from '../utils/logger';
+
+// ─── Types ────────────────────────────────────────────────────────────
+
+export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures before opening the circuit (default: 5) */
+  failureThreshold: number;
+  /** Time in ms before attempting to close an open circuit (default: 30000) */
+  resetTimeoutMs: number;
+  /** Number of successful calls in HALF_OPEN to close the circuit (default: 1) */
+  halfOpenSuccessThreshold: number;
+}
+
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default: 2) */
+  maxRetries: number;
+  /** Initial delay in ms before first retry (default: 1000) */
+  baseDelayMs: number;
+  /** Maximum delay in ms between retries (default: 10000) */
+  maxDelayMs: number;
+  /** Whether to retry on the given error. Defaults to retrying on network/5xx errors only. */
+  shouldRetry?: (error: unknown) => boolean;
+}
+
+export interface CircuitBreakerStatus {
+  name: string;
+  state: CircuitState;
+  failures: number;
+  lastFailureTime: string | null;
+  nextRetryTime: string | null;
+}
+
+// ─── Default retry predicate ─────────────────────────────────────────
+
+function isRetryableError(error: unknown): boolean {
+  if (!error) return false;
+
+  // Network errors (ECONNREFUSED, ECONNRESET, ETIMEDOUT, etc.)
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN'].includes(code)) {
+      return true;
+    }
+  }
+
+  // HTTP 5xx or 429 (rate limited)
+  const status = (error as { status?: number }).status
+    ?? (error as { response?: { status?: number } }).response?.status;
+  if (status !== undefined) {
+    return status >= 500 || status === 429;
+  }
+
+  // Timeout errors from AbortController
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+
+  return false;
+}
+
+// ─── CircuitBreaker ──────────────────────────────────────────────────
+
+const DEFAULT_CB_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 5,
+  resetTimeoutMs: 30_000,
+  halfOpenSuccessThreshold: 1,
+};
+
+export class CircuitBreaker {
+  readonly name: string;
+  private readonly opts: CircuitBreakerOptions;
+
+  private state: CircuitState = 'CLOSED';
+  private failures = 0;
+  private halfOpenSuccesses = 0;
+  private lastFailureTime: number | null = null;
+
+  constructor(name: string, options?: Partial<CircuitBreakerOptions>) {
+    this.name = name;
+    this.opts = { ...DEFAULT_CB_OPTIONS, ...options };
+  }
+
+  /**
+   * Execute a function through the circuit breaker.
+   * Throws CircuitOpenError if the circuit is open and reset timeout hasn't elapsed.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state === 'OPEN') {
+      if (this.shouldAttemptReset()) {
+        this.transitionTo('HALF_OPEN');
+      } else {
+        throw new CircuitOpenError(this.name, this.remainingResetMs());
+      }
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure(error);
+      throw error;
+    }
+  }
+
+  /** Current circuit state snapshot for health reporting. */
+  getStatus(): CircuitBreakerStatus {
+    return {
+      name: this.name,
+      state: this.state,
+      failures: this.failures,
+      lastFailureTime: this.lastFailureTime ? new Date(this.lastFailureTime).toISOString() : null,
+      nextRetryTime: this.state === 'OPEN' && this.lastFailureTime
+        ? new Date(this.lastFailureTime + this.opts.resetTimeoutMs).toISOString()
+        : null,
+    };
+  }
+
+  /** Reset the circuit to closed state (e.g., for testing or manual recovery). */
+  reset(): void {
+    this.transitionTo('CLOSED');
+    this.failures = 0;
+    this.halfOpenSuccesses = 0;
+    this.lastFailureTime = null;
+  }
+
+  // ── Internal ──
+
+  private onSuccess(): void {
+    if (this.state === 'HALF_OPEN') {
+      this.halfOpenSuccesses++;
+      if (this.halfOpenSuccesses >= this.opts.halfOpenSuccessThreshold) {
+        this.transitionTo('CLOSED');
+        this.failures = 0;
+        this.halfOpenSuccesses = 0;
+        this.lastFailureTime = null;
+      }
+    } else if (this.state === 'CLOSED') {
+      // Reset failure count on success (consecutive failure tracking)
+      this.failures = 0;
+    }
+  }
+
+  private onFailure(error: unknown): void {
+    this.failures++;
+    this.lastFailureTime = Date.now();
+
+    if (this.state === 'HALF_OPEN') {
+      // Any failure in half-open immediately re-opens
+      this.transitionTo('OPEN');
+      this.halfOpenSuccesses = 0;
+    } else if (this.state === 'CLOSED' && this.failures >= this.opts.failureThreshold) {
+      this.transitionTo('OPEN');
+    }
+
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.warn(`[CircuitBreaker:${this.name}] Failure #${this.failures}: ${msg}`);
+  }
+
+  private shouldAttemptReset(): boolean {
+    if (!this.lastFailureTime) return true;
+    return Date.now() - this.lastFailureTime >= this.opts.resetTimeoutMs;
+  }
+
+  private remainingResetMs(): number {
+    if (!this.lastFailureTime) return 0;
+    return Math.max(0, (this.lastFailureTime + this.opts.resetTimeoutMs) - Date.now());
+  }
+
+  private transitionTo(newState: CircuitState): void {
+    if (this.state === newState) return;
+    logger.info(`[CircuitBreaker:${this.name}] ${this.state} → ${newState}`);
+    this.state = newState;
+  }
+}
+
+// ─── CircuitOpenError ────────────────────────────────────────────────
+
+export class CircuitOpenError extends Error {
+  readonly serviceName: string;
+  readonly retryAfterMs: number;
+
+  constructor(serviceName: string, retryAfterMs: number) {
+    super(`Circuit breaker for ${serviceName} is OPEN. Retry after ${Math.ceil(retryAfterMs / 1000)}s.`);
+    this.name = 'CircuitOpenError';
+    this.serviceName = serviceName;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+// ─── Retry with exponential backoff ──────────────────────────────────
+
+const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  maxRetries: 2,
+  baseDelayMs: 1000,
+  maxDelayMs: 10_000,
+  shouldRetry: isRetryableError,
+};
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: Partial<RetryOptions>,
+): Promise<T> {
+  const opts = { ...DEFAULT_RETRY_OPTIONS, ...options };
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= opts.maxRetries || !opts.shouldRetry!(error)) {
+        throw error;
+      }
+
+      const delay = Math.min(
+        opts.baseDelayMs * Math.pow(2, attempt),
+        opts.maxDelayMs,
+      );
+      // Add jitter (±25%) to prevent thundering herd
+      const jitter = delay * (0.75 + Math.random() * 0.5);
+
+      logger.debug(`[Retry] Attempt ${attempt + 1}/${opts.maxRetries} failed, retrying in ${Math.round(jitter)}ms`);
+      await sleep(jitter);
+    }
+  }
+
+  throw lastError;
+}
+
+// ─── Timeout wrapper ─────────────────────────────────────────────────
+
+export async function withTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  label?: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TimeoutError(label || 'operation', timeoutMs));
+    }, timeoutMs);
+
+    fn().then(
+      (result) => { clearTimeout(timer); resolve(result); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+export class TimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+// ─── Composed resilience wrapper ─────────────────────────────────────
+
+export interface ResilienceOptions {
+  circuitBreaker?: CircuitBreaker;
+  retry?: Partial<RetryOptions>;
+  timeoutMs?: number;
+  label?: string;
+}
+
+/**
+ * Compose circuit breaker + retry + timeout in one call.
+ *
+ *   await withResilience(() => octokit.repos.get(...), {
+ *     circuitBreaker: githubBreaker,
+ *     retry: { maxRetries: 2 },
+ *     timeoutMs: 10_000,
+ *   });
+ */
+export async function withResilience<T>(
+  fn: () => Promise<T>,
+  options: ResilienceOptions,
+): Promise<T> {
+  const { circuitBreaker, retry, timeoutMs, label } = options;
+
+  const withTimeoutFn = timeoutMs
+    ? () => withTimeout(fn, timeoutMs, label)
+    : fn;
+
+  const withRetryFn = retry
+    ? () => withRetry(withTimeoutFn, retry)
+    : withTimeoutFn;
+
+  return circuitBreaker
+    ? circuitBreaker.execute(withRetryFn)
+    : withRetryFn();
+}
+
+// ─── Pre-configured breakers for external services ───────────────────
+
+export const circuitBreakers = {
+  github: new CircuitBreaker('github', {
+    failureThreshold: 5,
+    resetTimeoutMs: 30_000,
+  }),
+  jira: new CircuitBreaker('jira', {
+    failureThreshold: 5,
+    resetTimeoutMs: 30_000,
+  }),
+  jenkins: new CircuitBreaker('jenkins', {
+    failureThreshold: 3,
+    resetTimeoutMs: 60_000,
+  }),
+  confluence: new CircuitBreaker('confluence', {
+    failureThreshold: 5,
+    resetTimeoutMs: 30_000,
+  }),
+} as const;
+
+/** Snapshot of all circuit breaker states (for /health/full). */
+export function getAllCircuitBreakerStatuses(): CircuitBreakerStatus[] {
+  return Object.values(circuitBreakers).map(cb => cb.getStatus());
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/backend/src/services/confluence.service.ts
+++ b/backend/src/services/confluence.service.ts
@@ -3,6 +3,14 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/utils/logger';
 import { config } from '@/config';
 import { validateUrlForSSRF } from '@/utils/ssrf-validator';
+import { withResilience, circuitBreakers } from '@/lib/resilience';
+
+const CONFLUENCE_RESILIENCE = {
+  circuitBreaker: circuitBreakers.confluence,
+  retry: { maxRetries: 2, baseDelayMs: 1000 },
+  timeoutMs: 10_000,
+  label: 'confluence',
+};
 
 // Confluence API Types
 export interface ConfluenceConfig {
@@ -132,7 +140,10 @@ export class ConfluenceService {
     this.checkEnabled();
 
     try {
-      const response = await this.client!.get('/space');
+      const response = await withResilience(
+        () => this.client!.get('/space'),
+        CONFLUENCE_RESILIENCE,
+      );
       logger.info('Confluence connection validated successfully');
       return response.status === 200;
     } catch (error) {
@@ -153,7 +164,10 @@ export class ConfluenceService {
     }
 
     try {
-      const response = await this.client!.get(`/space/${key}`);
+      const response = await withResilience(
+        () => this.client!.get(`/space/${key}`),
+        CONFLUENCE_RESILIENCE,
+      );
       return response.data;
     } catch (error) {
       logger.error(`Failed to get Confluence space ${key}:`, error);
@@ -195,7 +209,10 @@ export class ConfluenceService {
         pageData.ancestors = [{ id: parent }];
       }
 
-      const response = await this.client!.post('/content', pageData);
+      const response = await withResilience(
+        () => this.client!.post('/content', pageData),
+        CONFLUENCE_RESILIENCE,
+      );
       const page: ConfluencePage = response.data;
 
       logger.info(`Created Confluence page: ${page.id} (${page.title})`);
@@ -232,7 +249,10 @@ export class ConfluenceService {
         },
       };
 
-      const response = await this.client!.put(`/content/${pageId}`, updateData);
+      const response = await withResilience(
+        () => this.client!.put(`/content/${pageId}`, updateData),
+        CONFLUENCE_RESILIENCE,
+      );
       logger.info(`Updated Confluence page: ${pageId}`);
       return response.data;
     } catch (error) {
@@ -248,11 +268,12 @@ export class ConfluenceService {
     this.checkEnabled();
 
     try {
-      const response = await this.client!.get(`/content/${pageId}`, {
-        params: {
-          expand: 'body.storage,version,space',
-        },
-      });
+      const response = await withResilience(
+        () => this.client!.get(`/content/${pageId}`, {
+          params: { expand: 'body.storage,version,space' },
+        }),
+        CONFLUENCE_RESILIENCE,
+      );
       return response.data;
     } catch (error) {
       logger.error(`Failed to get Confluence page ${pageId}:`, error);
@@ -272,13 +293,12 @@ export class ConfluenceService {
     }
 
     try {
-      const response = await this.client!.get('/content', {
-        params: {
-          spaceKey: space,
-          title: title,
-          expand: 'body.storage,version,space',
-        },
-      });
+      const response = await withResilience(
+        () => this.client!.get('/content', {
+          params: { spaceKey: space, title: title, expand: 'body.storage,version,space' },
+        }),
+        CONFLUENCE_RESILIENCE,
+      );
 
       const pages = response.data.results;
       return pages.length > 0 ? pages[0] : null;
@@ -297,10 +317,10 @@ export class ConfluenceService {
     try {
       await Promise.all(
         labels.map(label =>
-          this.client!.post(`/content/${pageId}/label`, {
-            prefix: 'global',
-            name: label,
-          })
+          withResilience(
+            () => this.client!.post(`/content/${pageId}/label`, { prefix: 'global', name: label }),
+            CONFLUENCE_RESILIENCE,
+          )
         )
       );
       logger.info(`Added ${labels.length} labels to page ${pageId}`);
@@ -500,13 +520,12 @@ export class ConfluenceService {
       }
       cql += ' ORDER BY lastModified DESC';
 
-      const response = await this.client!.get('/content/search', {
-        params: {
-          cql,
-          limit: maxResults,
-          expand: 'body.view,metadata.labels,space',
-        },
-      });
+      const response = await withResilience(
+        () => this.client!.get('/content/search', {
+          params: { cql, limit: maxResults, expand: 'body.view,metadata.labels,space' },
+        }),
+        CONFLUENCE_RESILIENCE,
+      );
 
       const results = (response.data.results || []).map((page: { id: string; title: string; body?: { view?: { value?: string } }; metadata?: { labels?: { results?: Array<{ name: string }> } }; _links?: { webui?: string } }) => {
         // Extract a text excerpt from the page body (strip HTML)

--- a/backend/src/services/github.service.ts
+++ b/backend/src/services/github.service.ts
@@ -4,6 +4,14 @@ import { logger } from '../utils/logger';
 import { PipelineStatus, TestStatus, PipelineType } from '../constants';
 import { Pipeline, TestRun, TestRunWithPipeline } from '../types/pipeline';
 import { sleep, generateUUID } from '../utils/common';
+import { withResilience, circuitBreakers } from '../lib/resilience';
+
+const GITHUB_RESILIENCE = {
+  circuitBreaker: circuitBreakers.github,
+  retry: { maxRetries: 2, baseDelayMs: 1000 },
+  timeoutMs: 10_000,
+  label: 'github',
+};
 
 interface GitHubWorkflowConfig {
   owner: string;
@@ -33,11 +41,10 @@ export class GitHubService {
       const { owner, repo, workflow } = this.parseConfig(config);
 
       // Try to get workflow info to validate connection
-      await this.octokit.actions.getWorkflow({
-        owner,
-        repo,
-        workflow_id: workflow
-      });
+      await withResilience(
+        () => this.octokit.actions.getWorkflow({ owner, repo, workflow_id: workflow }),
+        GITHUB_RESILIENCE,
+      );
     } catch (error) {
       logger.error('GitHub connection validation failed:', error);
       throw new Error('Failed to validate GitHub connection');
@@ -70,12 +77,15 @@ export class GitHubService {
       };
 
       // Start GitHub workflow
-      const response = await this.octokit.actions.createWorkflowDispatch({
-        owner: workflowConfig.owner,
-        repo: workflowConfig.repo,
-        workflow_id: workflowConfig.workflow,
-        ref: 'main'
-      });
+      const response = await withResilience(
+        () => this.octokit.actions.createWorkflowDispatch({
+          owner: workflowConfig.owner,
+          repo: workflowConfig.repo,
+          workflow_id: workflowConfig.workflow,
+          ref: 'main'
+        }),
+        GITHUB_RESILIENCE,
+      );
 
       if (response.status !== 204) {
         throw new Error('Failed to start GitHub workflow');
@@ -151,11 +161,10 @@ export class GitHubService {
     commitSha: string
   ): Promise<{ message: string; files: Array<{ filename: string; status: string; patch: string; additions: number; deletions: number }> }> {
     try {
-      const response = await this.octokit.repos.getCommit({
-        owner,
-        repo,
-        ref: commitSha,
-      });
+      const response = await withResilience(
+        () => this.octokit.repos.getCommit({ owner, repo, ref: commitSha }),
+        GITHUB_RESILIENCE,
+      );
 
       const commit = response.data;
       return {
@@ -183,11 +192,10 @@ export class GitHubService {
     commitSha: string
   ): Promise<{ number: number; title: string; body: string; url: string; author: string } | null> {
     try {
-      const response = await this.octokit.repos.listPullRequestsAssociatedWithCommit({
-        owner,
-        repo,
-        commit_sha: commitSha,
-      });
+      const response = await withResilience(
+        () => this.octokit.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha: commitSha }),
+        GITHUB_RESILIENCE,
+      );
 
       const prs = response.data;
       if (prs.length === 0) return null;
@@ -216,12 +224,10 @@ export class GitHubService {
     pullNumber: number
   ): Promise<Array<{ filename: string; status: string; patch: string; additions: number; deletions: number }>> {
     try {
-      const response = await this.octokit.pulls.listFiles({
-        owner,
-        repo,
-        pull_number: pullNumber,
-        per_page: 100,
-      });
+      const response = await withResilience(
+        () => this.octokit.pulls.listFiles({ owner, repo, pull_number: pullNumber, per_page: 100 }),
+        GITHUB_RESILIENCE,
+      );
 
       return response.data.map((f) => ({
         filename: f.filename,
@@ -248,14 +254,10 @@ export class GitHubService {
     base: string
   ): Promise<{ number: number; title: string; url: string; }> {
     try {
-      const response = await this.octokit.pulls.create({
-        owner,
-        repo,
-        title,
-        body,
-        head,
-        base,
-      });
+      const response = await withResilience(
+        () => this.octokit.pulls.create({ owner, repo, title, body, head, base }),
+        GITHUB_RESILIENCE,
+      );
 
       logger.info(`Created PR #${response.data.number}: "${title}" in ${owner}/${repo}`);
 
@@ -276,21 +278,18 @@ export class GitHubService {
   async createBranch(owner: string, repo: string, branchName: string, baseBranch: string = 'main'): Promise<void> {
     try {
       // Get the SHA of the base branch
-      const baseRef = await this.octokit.git.getRef({
-        owner,
-        repo,
-        ref: `heads/${baseBranch}`,
-      });
+      const baseRef = await withResilience(
+        () => this.octokit.git.getRef({ owner, repo, ref: `heads/${baseBranch}` }),
+        GITHUB_RESILIENCE,
+      );
 
       const sha = baseRef.data.object.sha;
 
       // Create the new branch
-      await this.octokit.git.createRef({
-        owner,
-        repo,
-        ref: `refs/heads/${branchName}`,
-        sha,
-      });
+      await withResilience(
+        () => this.octokit.git.createRef({ owner, repo, ref: `refs/heads/${branchName}`, sha }),
+        GITHUB_RESILIENCE,
+      );
 
       logger.info(`Created branch ${branchName} from ${baseBranch} in ${owner}/${repo}`);
     } catch (error) {
@@ -327,16 +326,19 @@ export class GitHubService {
         // File doesn't exist, which is fine (we'll create it)
       }
 
-      const response = await this.octokit.repos.createOrUpdateFileContents({
-        owner,
-        repo,
-        path,
-        message,
-        content: Buffer.from(content).toString('base64'),
-        branch,
-        ...(sha ? { sha } : {}),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      const response = await withResilience(
+        () => this.octokit.repos.createOrUpdateFileContents({
+          owner,
+          repo,
+          path,
+          message,
+          content: Buffer.from(content).toString('base64'),
+          branch,
+          ...(sha ? { sha } : {}),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any),
+        GITHUB_RESILIENCE,
+      );
 
       return {
         sha: response.data.commit.sha as string,
@@ -358,12 +360,10 @@ export class GitHubService {
     branch: string = 'main'
   ): Promise<void> {
     try {
-      const response = await this.octokit.actions.createWorkflowDispatch({
-        owner,
-        repo,
-        workflow_id: workflowId,
-        ref: branch,
-      });
+      const response = await withResilience(
+        () => this.octokit.actions.createWorkflowDispatch({ owner, repo, workflow_id: workflowId, ref: branch }),
+        GITHUB_RESILIENCE,
+      );
 
       if (response.status !== 204) {
         throw new Error(`Unexpected status ${response.status} from workflow dispatch`);
@@ -392,13 +392,16 @@ export class GitHubService {
 
     try {
       const mergeMethod = options.method || 'squash';
-      const { data } = await this.octokit!.pulls.merge({
-        owner,
-        repo,
-        pull_number: prNumber,
-        merge_method: mergeMethod as 'merge' | 'squash' | 'rebase',
-        ...(options.commitMessage ? { commit_message: options.commitMessage } : {}),
-      });
+      const { data } = await withResilience(
+        () => this.octokit!.pulls.merge({
+          owner,
+          repo,
+          pull_number: prNumber,
+          merge_method: mergeMethod as 'merge' | 'squash' | 'rebase',
+          ...(options.commitMessage ? { commit_message: options.commitMessage } : {}),
+        }),
+        GITHUB_RESILIENCE,
+      );
 
       logger.info(`[GitHubService] Merged PR #${prNumber} in ${owner}/${repo} via ${mergeMethod}`);
 

--- a/backend/src/services/jenkins.service.ts
+++ b/backend/src/services/jenkins.service.ts
@@ -3,6 +3,14 @@ import { Pipeline, TestRun } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/utils/logger';
 import { validateUrlForSSRF, validateSameOrigin } from '@/utils/ssrf-validator';
+import { withResilience, circuitBreakers } from '@/lib/resilience';
+
+const JENKINS_RESILIENCE = {
+  circuitBreaker: circuitBreakers.jenkins,
+  retry: { maxRetries: 1, baseDelayMs: 1000 },
+  timeoutMs: 15_000,
+  label: 'jenkins',
+};
 
 interface JenkinsConfig {
   url: string;
@@ -56,11 +64,12 @@ export class JenkinsService {
     this.validateUrl(config.url);
 
     try {
-      const response = await this.client.get(`${config.url}/api/json`, {
-        headers: {
-          Authorization: this.createAuthHeader(config.credentials),
-        },
-      });
+      const response = await withResilience(
+        () => this.client.get(`${config.url}/api/json`, {
+          headers: { Authorization: this.createAuthHeader(config.credentials) },
+        }),
+        JENKINS_RESILIENCE,
+      );
 
       if (response.status !== 200) {
         throw new Error('Failed to connect to Jenkins');
@@ -95,14 +104,13 @@ export class JenkinsService {
       });
 
       // Trigger Jenkins build
-      const response = await this.client.post(
-        `${config.url}/job/${encodeURIComponent(pipeline.name)}/buildWithParameters`,
-        buildParams,
-        {
-          headers: {
-            Authorization: this.createAuthHeader(config.credentials),
-          },
-        }
+      const response = await withResilience(
+        () => this.client.post(
+          `${config.url}/job/${encodeURIComponent(pipeline.name)}/buildWithParameters`,
+          buildParams,
+          { headers: { Authorization: this.createAuthHeader(config.credentials) } },
+        ),
+        JENKINS_RESILIENCE,
       );
 
       if (response.status !== 201) {

--- a/backend/src/services/jira.service.ts
+++ b/backend/src/services/jira.service.ts
@@ -8,6 +8,14 @@ import {
   UpdateIssueDTO,
   JiraIssueResponse
 } from '@/types/jira';
+import { withResilience, circuitBreakers } from '@/lib/resilience';
+
+const JIRA_RESILIENCE = {
+  circuitBreaker: circuitBreakers.jira,
+  retry: { maxRetries: 2, baseDelayMs: 1000 },
+  timeoutMs: 10_000,
+  label: 'jira',
+};
 
 export class JiraService {
   private client: JiraClient | null = null;
@@ -62,15 +70,18 @@ export class JiraService {
         issue = { key: `MOCK-${Date.now()}`, id: `mock-id-${Date.now()}` };
       } else {
         // Create issue in Jira
-        issue = await this.client!.addNewIssue({
-          fields: {
-            project: { key: this.projectKey },
-            summary: data.summary,
-            description: data.description,
-            issuetype: { name: data.type },
-            labels: data.labels || [],
-          },
-        });
+        issue = await withResilience(
+          () => this.client!.addNewIssue({
+            fields: {
+              project: { key: this.projectKey },
+              summary: data.summary,
+              description: data.description,
+              issuetype: { name: data.type },
+              labels: data.labels || [],
+            },
+          }),
+          JIRA_RESILIENCE,
+        );
       }
 
       // Store issue in our database
@@ -104,13 +115,16 @@ export class JiraService {
 
     try {
       // Update issue in Jira
-      await this.client!.updateIssue(jiraKey, {
-        fields: {
-          ...(data.summary && { summary: data.summary }),
-          ...(data.description && { description: data.description }),
-          ...(data.labels && { labels: data.labels }),
-        },
-      });
+      await withResilience(
+        () => this.client!.updateIssue(jiraKey, {
+          fields: {
+            ...(data.summary && { summary: data.summary }),
+            ...(data.description && { description: data.description }),
+            ...(data.labels && { labels: data.labels }),
+          },
+        }),
+        JIRA_RESILIENCE,
+      );
 
       // If status is provided, transition the issue
       if (data.status) {
@@ -139,7 +153,10 @@ export class JiraService {
     this.checkEnabled();
 
     try {
-      const issue = await this.client!.findIssue(jiraKey);
+      const issue = await withResilience(
+        () => this.client!.findIssue(jiraKey),
+        JIRA_RESILIENCE,
+      );
       return {
         id: issue.id,
         key: issue.key,
@@ -180,9 +197,10 @@ export class JiraService {
       });
 
       // Add comment to Jira issue
-      await this.client!.addComment(jiraKey, {
-        body: `Linked to test run: ${testRunId}`,
-      });
+      await withResilience(
+        () => this.client!.addComment(jiraKey, { body: `Linked to test run: ${testRunId}` }),
+        JIRA_RESILIENCE,
+      );
 
       logger.info(`Linked test run ${testRunId} to Jira issue ${jiraKey}`);
     } catch (error) {
@@ -232,10 +250,13 @@ export class JiraService {
 
       jql += ' ORDER BY updated DESC';
 
-      const result = await this.client!.searchJira(jql, {
-        maxResults,
-        fields: ['summary', 'description', 'status', 'issuetype', 'labels', 'updated', 'created', 'assignee', 'priority'],
-      });
+      const result = await withResilience(
+        () => this.client!.searchJira(jql, {
+          maxResults,
+          fields: ['summary', 'description', 'status', 'issuetype', 'labels', 'updated', 'created', 'assignee', 'priority'],
+        }),
+        JIRA_RESILIENCE,
+      );
 
       const issues: JiraIssueResponse[] = (result.issues || []).map((issue: { id: string; key: string; fields: Record<string, unknown> & { summary?: string; description?: string; status?: { name?: string }; issuetype?: { name?: string }; labels?: string[]; priority?: { name?: string }; assignee?: { displayName?: string } } }) => ({
         id: issue.id,
@@ -311,7 +332,10 @@ export class JiraService {
 
     try {
       // Get available transitions
-      const transitions = await this.client!.listTransitions(issueKey);
+      const transitions = await withResilience(
+        () => this.client!.listTransitions(issueKey),
+        JIRA_RESILIENCE,
+      );
 
       // Map our status to Jira transition
       const transitionMap: Record<JiraIssueStatus, string> = {
@@ -330,9 +354,10 @@ export class JiraService {
       }
 
       // Perform the transition
-      await this.client!.transitionIssue(issueKey, {
-        transition: { id: targetTransition.id },
-      });
+      await withResilience(
+        () => this.client!.transitionIssue(issueKey, { transition: { id: targetTransition.id } }),
+        JIRA_RESILIENCE,
+      );
 
       logger.info(`Transitioned Jira issue ${issueKey} to ${status}`);
     } catch (error) {
@@ -348,7 +373,10 @@ export class JiraService {
     this.checkEnabled();
 
     try {
-      await this.client!.addComment(issueKey, { body });
+      await withResilience(
+        () => this.client!.addComment(issueKey, { body }),
+        JIRA_RESILIENCE,
+      );
       logger.info(`Added comment to Jira issue ${issueKey}`);
     } catch (error) {
       logger.error(`Failed to add comment to ${issueKey}:`, error);
@@ -365,11 +393,14 @@ export class JiraService {
 
     try {
       // jira-client types don't expose issueLink, but the REST API supports it
-      await (this.client as any).issueLink({
-        type: { name: linkType },
-        inwardIssue: { key: sourceKey },
-        outwardIssue: { key: targetKey },
-      });
+      await withResilience(
+        () => (this.client as any).issueLink({
+          type: { name: linkType },
+          inwardIssue: { key: sourceKey },
+          outwardIssue: { key: targetKey },
+        }),
+        JIRA_RESILIENCE,
+      );
       logger.info(`Linked Jira issues ${sourceKey} → ${targetKey} (${linkType})`);
     } catch (error) {
       logger.error(`Failed to link ${sourceKey} to ${targetKey}:`, error);
@@ -386,12 +417,15 @@ export class JiraService {
 
     try {
       // Use the Jira REST API 'update' field operator for atomic label additions
-      await this.client!.updateIssue(issueKey, {
-        fields: {},
-        update: {
-          labels: labels.map(label => ({ add: label })),
-        },
-      } as any);
+      await withResilience(
+        () => this.client!.updateIssue(issueKey, {
+          fields: {},
+          update: {
+            labels: labels.map(label => ({ add: label })),
+          },
+        } as any),
+        JIRA_RESILIENCE,
+      );
       logger.info(`Added labels [${labels.join(', ')}] to ${issueKey}`);
     } catch (error) {
       logger.error(`Failed to add labels to ${issueKey}:`, error);


### PR DESCRIPTION
…services

External service calls (GitHub, Jira, Jenkins, Confluence) now have fault tolerance via a lightweight resilience layer:

- CircuitBreaker: CLOSED → OPEN → HALF_OPEN state machine per service
- Retry with exponential backoff + jitter for transient failures
- Timeout enforcement per request
- Pre-configured breakers with tuned thresholds per service
- Circuit breaker state exposed in /health/full endpoint
- 30 unit tests covering state transitions, retry, timeout, composition

When Jira (or any integration) goes down, the circuit opens after the configured failure threshold and fast-fails subsequent calls instead of blocking. After the reset timeout, it auto-probes with a half-open call.

https://claude.ai/code/session_015d6x8mye7W53vGJRvADL6m

