### PR TITLE
feat(specs): Phase 3 — coverage thresholds, PR reports, health dashboard

### DIFF
--- a/.github/workflows/feature-specs.yml
+++ b/.github/workflows/feature-specs.yml
@@ -1,0 +1,97 @@
+name: Feature Spec Validation
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'specs/features/**'
+      - 'backend/src/**/__tests__/**'
+      - 'scripts/scan-feature-specs.ts'
+      - 'scripts/feature-health-report.ts'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'specs/features/**'
+      - 'backend/src/**'
+      - 'frontend/src/**'
+      - 'scripts/scan-feature-specs.ts'
+      - 'scripts/feature-health-report.ts'
+
+env:
+  SPEC_BEHAVIORAL_THRESHOLD: "80"
+  SPEC_CONTRACT_THRESHOLD: "80"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install root dependencies
+      run: npm ci --ignore-scripts
+
+    - name: Install backend dependencies
+      working-directory: ./backend
+      run: npm ci
+
+    - name: Generate Prisma Client
+      working-directory: ./backend
+      run: npx prisma generate
+
+    - name: Validate feature specs (thresholds enforced)
+      run: npx tsx scripts/scan-feature-specs.ts
+
+    - name: Generate coverage report (JSON)
+      if: always()
+      run: npx tsx scripts/scan-feature-specs.ts --json > /tmp/spec-report.json 2>/dev/null || true
+
+    - name: Generate PR comment
+      if: github.event_name == 'pull_request'
+      id: report
+      run: |
+        REPORT=$(npx tsx scripts/feature-health-report.ts --pr)
+        # Write to file for gh pr comment
+        echo "$REPORT" > /tmp/pr-comment.md
+
+    - name: Post coverage report to PR
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const body = fs.readFileSync('/tmp/pr-comment.md', 'utf-8');
+
+          // Find existing comment to update (avoid duplicates)
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const marker = '## Feature Spec Coverage Report';
+          const existing = comments.find(c => c.body.startsWith(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/backend/src/__tests__/helpers/spec-version-tracker.json
+++ b/backend/src/__tests__/helpers/spec-version-tracker.json
@@ -18,7 +18,7 @@
       "housekeeping.suggestion": "1.0.0",
       "housekeeping.undo": "1.0.0"
     },
-    "lastRun": "2026-02-21T11:45:33.353Z"
+    "lastRun": "2026-02-21T12:07:41.557Z"
   },
   "giphy-integration": {
     "lastTestedVersion": "1.0.0",
@@ -28,7 +28,7 @@
       "giphy.frontend": "1.0.0",
       "giphy.autonomy": "1.0.0"
     },
-    "lastRun": "2026-02-21T11:45:33.384Z"
+    "lastRun": "2026-02-21T12:07:41.340Z"
   },
   "autonomy-preferences": {
     "lastTestedVersion": "1.0.0",
@@ -40,7 +40,7 @@
       "autonomy.frontend": "1.0.0",
       "autonomy.api": "1.0.0"
     },
-    "lastRun": "2026-02-21T11:45:33.448Z"
+    "lastRun": "2026-02-21T12:07:41.489Z"
   },
   "inline-diff": {
     "lastTestedVersion": "1.0.0",
@@ -49,6 +49,6 @@
       "diff.pr-card": "1.0.0",
       "diff.merge-tool": "1.0.0"
     },
-    "lastRun": "2026-02-21T11:45:33.515Z"
+    "lastRun": "2026-02-21T12:07:41.510Z"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.ts --headed",
     "test:all": "npm run test && npm run test:e2e",
-    "validate:specs": "npx tsx scripts/scan-feature-specs.ts"
+    "validate:specs": "npx tsx scripts/scan-feature-specs.ts",
+    "validate:specs:json": "npx tsx scripts/scan-feature-specs.ts --json",
+    "report:specs": "npx tsx scripts/feature-health-report.ts --pr",
+    "report:specs:dashboard": "npx tsx scripts/feature-health-report.ts --dashboard"
   },
   "keywords": [
     "test",

--- a/plans/2026-02-21-living-feature-specs.md
+++ b/plans/2026-02-21-living-feature-specs.md
@@ -427,7 +427,7 @@ These were chosen because:
 
 ## Migration Strategy
 
-### Phase 1: Foundation (this PR)
+### Phase 1: Foundation — COMPLETE
 - Create `specs/features/` directory structure
 - Implement `_schema.ts` types
 - Implement `registry.ts` loader/validator
@@ -437,15 +437,20 @@ These were chosen because:
 - Update `_SPEC_INDEX.md` with feature spec documentation
 - Scanner runs in CI as advisory (non-blocking)
 
-### Phase 2: Adoption (next sprint)
+### Phase 2: Adoption — COMPLETE
 - Convert existing tests to use `describeFeature()` / `itAssertion()` where applicable
 - Create manifests for remaining features (Proactive Suggestions, Inline Diff, Autonomy Preferences)
 - Scanner becomes blocking for invariant coverage (all invariants must have tests)
+- 103 assertions across 6 features, all tested
 
-### Phase 3: Maturity (sprint after)
-- Behavioral coverage thresholds enforced
-- Auto-generated coverage report in PR comments
-- Feature health dashboard (which features have drift, coverage gaps)
+### Phase 3: Maturity — COMPLETE
+- Behavioral coverage thresholds enforced (default 80%, configurable via `SPEC_BEHAVIORAL_THRESHOLD`)
+- Contract coverage thresholds enforced (default 80%, configurable via `SPEC_CONTRACT_THRESHOLD`)
+- `--json` output mode for scanner (`npm run validate:specs:json`)
+- Auto-generated coverage report for PR comments (`npm run report:specs`)
+- Feature health dashboard with per-capability breakdown (`npm run report:specs:dashboard`)
+- GitHub Actions workflow (`.github/workflows/feature-specs.yml`) auto-posts coverage to PRs
+- Health scoring: A+ (100%) through D (<70%) grading system
 
 ---
 

--- a/scripts/feature-health-report.ts
+++ b/scripts/feature-health-report.ts
@@ -1,0 +1,461 @@
+#!/usr/bin/env tsx
+/**
+ * Feature Health Report Generator — Phase 3 Maturity
+ *
+ * Generates markdown reports from the feature spec scanner's structured data.
+ * Two output modes:
+ *   --pr       GitHub PR comment (concise, table-based)
+ *   --dashboard  Full health dashboard (detailed, per-capability breakdown)
+ *
+ * Usage:
+ *   npx tsx scripts/feature-health-report.ts --pr         # PR comment markdown
+ *   npx tsx scripts/feature-health-report.ts --dashboard  # Full health dashboard
+ *   npm run report:specs                                   # Default: PR comment
+ *   npm run report:specs:dashboard                         # Health dashboard
+ *
+ * Input: Runs the scanner internally (no piping needed).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import {
+  type FeatureManifest,
+  type ValidationError,
+  validateManifest,
+} from '../specs/features/_schema';
+
+// --- Re-use scanner types and logic ---
+
+const ROOT = path.resolve(__dirname, '..');
+const FEATURES_DIR = path.join(ROOT, 'specs', 'features');
+const BACKEND_SRC = path.join(ROOT, 'backend', 'src');
+const FRONTEND_SRC = path.join(ROOT, 'frontend', 'src');
+const TRACKER_PATH = path.join(ROOT, 'backend', 'src', '__tests__', 'helpers', 'spec-version-tracker.json');
+
+const args = process.argv.slice(2);
+const MODE = args.includes('--dashboard') ? 'dashboard' : 'pr';
+
+// --- Types ---
+
+interface FeatureHealth {
+  featureId: string;
+  name: string;
+  version: string;
+  status: string;
+  owner: string;
+  total: number;
+  tested: number;
+  coverage: number;
+  invariantTotal: number;
+  invariantTested: number;
+  behavioralTotal: number;
+  behavioralTested: number;
+  contractTotal: number;
+  contractTested: number;
+  driftCount: number;
+  untestedIds: string[];
+  lastTested: string | null;
+  capabilities: CapHealth[];
+}
+
+interface CapHealth {
+  id: string;
+  version: string;
+  total: number;
+  tested: number;
+  hasDrift: boolean;
+}
+
+interface HealthSummary {
+  timestamp: string;
+  featureCount: number;
+  totalAssertions: number;
+  totalTested: number;
+  overallCoverage: number;
+  invariantCoverage: number;
+  behavioralCoverage: number;
+  contractCoverage: number;
+  featuresWithDrift: number;
+  featuresAt100: number;
+  features: FeatureHealth[];
+}
+
+// --- Helpers (copied from scanner to avoid import issues) ---
+
+function findTestFiles(): string[] {
+  const testDirs = [
+    path.join(BACKEND_SRC, '__tests__'),
+    path.join(BACKEND_SRC, 'services', 'ai', '__tests__'),
+    path.join(BACKEND_SRC, 'middleware', '__tests__'),
+    path.join(BACKEND_SRC, 'lib', '__tests__'),
+    path.join(FRONTEND_SRC, 'components'),
+    path.join(FRONTEND_SRC, 'contexts'),
+    path.join(FRONTEND_SRC, 'hooks'),
+  ];
+
+  const files: string[] = [];
+
+  function walk(dir: string): void {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts') || entry.name.endsWith('.test.tsx') || entry.name.endsWith('.spec.tsx')) {
+        files.push(full);
+      }
+    }
+  }
+
+  for (const dir of testDirs) {
+    walk(dir);
+  }
+
+  return files;
+}
+
+function extractTestedAssertionIds(testFiles: string[]): Set<string> {
+  const ids = new Set<string>();
+  const pattern = /itAssertion\(\s*['"`]([^'"`]+)['"`]/g;
+
+  for (const file of testFiles) {
+    const content = fs.readFileSync(file, 'utf-8');
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+      ids.add(match[1]);
+    }
+  }
+
+  return ids;
+}
+
+function loadVersionTracker(): Record<string, { lastTestedVersion: string; capabilities: Record<string, string>; lastRun: string }> {
+  try {
+    const raw = fs.readFileSync(TRACKER_PATH, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function pct(tested: number, total: number): number {
+  return total > 0 ? Math.round((tested / total) * 100) : 100;
+}
+
+// --- Data collection ---
+
+function collectHealthData(): HealthSummary {
+  const yamlFiles = fs.readdirSync(FEATURES_DIR).filter(f => f.endsWith('.feature.yaml'));
+  const testFiles = findTestFiles();
+  const testedIds = extractTestedAssertionIds(testFiles);
+  const tracker = loadVersionTracker();
+
+  let totalAssertions = 0;
+  let totalTested = 0;
+  let invariantTotal = 0;
+  let invariantTested = 0;
+  let behavioralTotal = 0;
+  let behavioralTested = 0;
+  let contractTotal = 0;
+  let contractTested = 0;
+  let featuresWithDrift = 0;
+  let featuresAt100 = 0;
+
+  const features: FeatureHealth[] = [];
+
+  for (const file of yamlFiles) {
+    const filePath = path.join(FEATURES_DIR, file);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = yaml.load(content);
+    const errors = validateManifest(parsed);
+    if (errors.length > 0) continue;
+
+    const manifest = parsed as FeatureManifest;
+    const trackerRecord = tracker[manifest.feature];
+
+    const fh: FeatureHealth = {
+      featureId: manifest.feature,
+      name: manifest.name,
+      version: manifest.version,
+      status: manifest.status,
+      owner: manifest.owner,
+      total: 0,
+      tested: 0,
+      coverage: 0,
+      invariantTotal: 0,
+      invariantTested: 0,
+      behavioralTotal: 0,
+      behavioralTested: 0,
+      contractTotal: 0,
+      contractTested: 0,
+      driftCount: 0,
+      untestedIds: [],
+      lastTested: trackerRecord?.lastRun ?? null,
+      capabilities: [],
+    };
+
+    for (const cap of manifest.capabilities) {
+      const ch: CapHealth = {
+        id: cap.id,
+        version: cap.version,
+        total: cap.assertions.length,
+        tested: 0,
+        hasDrift: false,
+      };
+
+      // Check drift
+      if (trackerRecord) {
+        const lastVer = trackerRecord.capabilities?.[cap.id];
+        if (lastVer && lastVer !== cap.version) {
+          ch.hasDrift = true;
+          fh.driftCount++;
+        }
+      }
+
+      for (const assertion of cap.assertions) {
+        fh.total++;
+        totalAssertions++;
+
+        if (assertion.type === 'invariant') { fh.invariantTotal++; invariantTotal++; }
+        else if (assertion.type === 'behavioral') { fh.behavioralTotal++; behavioralTotal++; }
+        else { fh.contractTotal++; contractTotal++; }
+
+        if (testedIds.has(assertion.id)) {
+          fh.tested++;
+          ch.tested++;
+          totalTested++;
+          if (assertion.type === 'invariant') { fh.invariantTested++; invariantTested++; }
+          else if (assertion.type === 'behavioral') { fh.behavioralTested++; behavioralTested++; }
+          else { fh.contractTested++; contractTested++; }
+        } else if (!assertion.deprecated) {
+          fh.untestedIds.push(assertion.id);
+        }
+      }
+
+      fh.capabilities.push(ch);
+    }
+
+    fh.coverage = pct(fh.tested, fh.total);
+    if (fh.driftCount > 0) featuresWithDrift++;
+    if (fh.coverage === 100) featuresAt100++;
+    features.push(fh);
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    featureCount: features.length,
+    totalAssertions,
+    totalTested,
+    overallCoverage: pct(totalTested, totalAssertions),
+    invariantCoverage: pct(invariantTested, invariantTotal),
+    behavioralCoverage: pct(behavioralTested, behavioralTotal),
+    contractCoverage: pct(contractTested, contractTotal),
+    featuresWithDrift,
+    featuresAt100,
+    features,
+  };
+}
+
+// --- Markdown generators ---
+
+function healthIcon(coverage: number): string {
+  if (coverage === 100) return '🟢';
+  if (coverage >= 80) return '🟡';
+  return '🔴';
+}
+
+function generatePRComment(data: HealthSummary): string {
+  const lines: string[] = [];
+
+  lines.push('## Feature Spec Coverage Report');
+  lines.push('');
+  lines.push(`> ${data.featureCount} features · ${data.totalAssertions} assertions · ${data.timestamp.split('T')[0]}`);
+  lines.push('');
+
+  // Overall coverage bar
+  lines.push(`**Overall: ${data.overallCoverage}%** (${data.totalTested}/${data.totalAssertions})`);
+  lines.push('');
+
+  // Type breakdown
+  lines.push('| Type | Tested | Total | Coverage |');
+  lines.push('|------|--------|-------|----------|');
+  lines.push(`| Invariant | ${data.features.reduce((s, f) => s + f.invariantTested, 0)} | ${data.features.reduce((s, f) => s + f.invariantTotal, 0)} | ${data.invariantCoverage}% |`);
+  lines.push(`| Behavioral | ${data.features.reduce((s, f) => s + f.behavioralTested, 0)} | ${data.features.reduce((s, f) => s + f.behavioralTotal, 0)} | ${data.behavioralCoverage}% |`);
+  lines.push(`| Contract | ${data.features.reduce((s, f) => s + f.contractTested, 0)} | ${data.features.reduce((s, f) => s + f.contractTotal, 0)} | ${data.contractCoverage}% |`);
+  lines.push('');
+
+  // Per-feature table
+  lines.push('### Per-Feature Breakdown');
+  lines.push('');
+  lines.push('| Feature | Version | Assertions | Tested | Coverage | Drift |');
+  lines.push('|---------|---------|------------|--------|----------|-------|');
+
+  for (const f of data.features) {
+    const drift = f.driftCount > 0 ? `${f.driftCount} cap(s)` : '-';
+    lines.push(
+      `| ${healthIcon(f.coverage)} ${f.name} | v${f.version} | ${f.total} | ${f.tested} | ${f.coverage}% | ${drift} |`,
+    );
+  }
+
+  lines.push('');
+
+  // Untested assertions (if any)
+  const allUntested = data.features.flatMap(f => f.untestedIds.map(id => `\`${id}\``));
+  if (allUntested.length > 0) {
+    lines.push('<details>');
+    lines.push(`<summary>Untested assertions (${allUntested.length})</summary>`);
+    lines.push('');
+    for (const id of allUntested) {
+      lines.push(`- ${id}`);
+    }
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  // Drift summary
+  if (data.featuresWithDrift > 0) {
+    lines.push(`> **Version drift detected** in ${data.featuresWithDrift} feature(s). Run tests to update tracker.`);
+    lines.push('');
+  }
+
+  // Footer
+  lines.push('---');
+  lines.push('*Generated by `npm run report:specs` · [Feature Spec System](plans/2026-02-21-living-feature-specs.md)*');
+
+  return lines.join('\n');
+}
+
+function generateDashboard(data: HealthSummary): string {
+  const lines: string[] = [];
+
+  lines.push('# Feature Health Dashboard');
+  lines.push('');
+  lines.push(`> **Generated**: ${data.timestamp}`);
+  lines.push(`> **Features**: ${data.featureCount} · **Assertions**: ${data.totalAssertions} · **Tested**: ${data.totalTested}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  // Overall health score
+  const score = data.overallCoverage;
+  const grade = score === 100 ? 'A+' : score >= 90 ? 'A' : score >= 80 ? 'B' : score >= 70 ? 'C' : 'D';
+  lines.push(`## Health Score: ${grade} (${score}%)`);
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Overall coverage | ${score}% (${data.totalTested}/${data.totalAssertions}) |`);
+  lines.push(`| Invariant coverage | ${data.invariantCoverage}% |`);
+  lines.push(`| Behavioral coverage | ${data.behavioralCoverage}% |`);
+  lines.push(`| Contract coverage | ${data.contractCoverage}% |`);
+  lines.push(`| Features at 100% | ${data.featuresAt100}/${data.featureCount} |`);
+  lines.push(`| Features with drift | ${data.featuresWithDrift} |`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  // Per-feature detail
+  lines.push('## Feature Details');
+  lines.push('');
+
+  for (const f of data.features) {
+    lines.push(`### ${healthIcon(f.coverage)} ${f.name} (v${f.version})`);
+    lines.push('');
+    lines.push(`| Property | Value |`);
+    lines.push(`|----------|-------|`);
+    lines.push(`| Status | ${f.status} |`);
+    lines.push(`| Owner | ${f.owner} |`);
+    lines.push(`| Coverage | ${f.coverage}% (${f.tested}/${f.total}) |`);
+    lines.push(`| Invariants | ${f.invariantTested}/${f.invariantTotal} |`);
+    lines.push(`| Behavioral | ${f.behavioralTested}/${f.behavioralTotal} |`);
+    lines.push(`| Contracts | ${f.contractTested}/${f.contractTotal} |`);
+    lines.push(`| Last tested | ${f.lastTested ? f.lastTested.split('T')[0] : 'Never'} |`);
+    lines.push(`| Version drift | ${f.driftCount > 0 ? `${f.driftCount} capability(ies)` : 'None'} |`);
+    lines.push('');
+
+    // Capability breakdown
+    lines.push('**Capabilities:**');
+    lines.push('');
+    lines.push('| Capability | Version | Tested | Total | Drift |');
+    lines.push('|------------|---------|--------|-------|-------|');
+    for (const c of f.capabilities) {
+      const driftMark = c.hasDrift ? 'YES' : '-';
+      lines.push(`| ${c.id} | v${c.version} | ${c.tested} | ${c.total} | ${driftMark} |`);
+    }
+    lines.push('');
+
+    if (f.untestedIds.length > 0) {
+      lines.push('**Untested assertions:**');
+      for (const id of f.untestedIds) {
+        lines.push(`- \`${id}\``);
+      }
+      lines.push('');
+    }
+  }
+
+  lines.push('---');
+  lines.push('');
+
+  // Actionable items
+  const allUntested = data.features.flatMap(f => f.untestedIds);
+  const driftFeatures = data.features.filter(f => f.driftCount > 0);
+
+  if (allUntested.length > 0 || driftFeatures.length > 0) {
+    lines.push('## Action Items');
+    lines.push('');
+
+    if (allUntested.length > 0) {
+      lines.push(`### Untested Assertions (${allUntested.length})`);
+      lines.push('');
+      for (const f of data.features) {
+        if (f.untestedIds.length > 0) {
+          lines.push(`**${f.name}:**`);
+          for (const id of f.untestedIds) {
+            lines.push(`- [ ] \`${id}\``);
+          }
+          lines.push('');
+        }
+      }
+    }
+
+    if (driftFeatures.length > 0) {
+      lines.push('### Version Drift');
+      lines.push('');
+      for (const f of driftFeatures) {
+        const driftCaps = f.capabilities.filter(c => c.hasDrift);
+        lines.push(`**${f.name}:** ${driftCaps.map(c => c.id).join(', ')}`);
+      }
+      lines.push('');
+    }
+  } else {
+    lines.push('## Action Items');
+    lines.push('');
+    lines.push('None — all assertions tested, no drift detected.');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('*Generated by `npm run report:specs:dashboard` · Phase 3: Feature Spec Maturity*');
+
+  return lines.join('\n');
+}
+
+// --- Main ---
+
+function main(): void {
+  if (!fs.existsSync(FEATURES_DIR)) {
+    console.error('ERROR: specs/features/ directory does not exist');
+    process.exit(1);
+  }
+
+  const data = collectHealthData();
+
+  if (MODE === 'dashboard') {
+    console.log(generateDashboard(data));
+  } else {
+    console.log(generatePRComment(data));
+  }
+}
+
+main();

--- a/scripts/scan-feature-specs.ts
+++ b/scripts/scan-feature-specs.ts
@@ -3,8 +3,9 @@
  * Feature Spec Scanner — Validates manifests, detects orphans, reports coverage.
  *
  * Usage:
- *   npx tsx scripts/scan-feature-specs.ts
- *   npm run validate:specs
+ *   npx tsx scripts/scan-feature-specs.ts          # Human-readable output
+ *   npx tsx scripts/scan-feature-specs.ts --json    # JSON output for tooling
+ *   npm run validate:specs                          # Advisory mode (thresholds enforced)
  *
  * Checks:
  *   - Schema validation (ERROR)
@@ -14,6 +15,11 @@
  *   - Orphaned assertions — in manifest but no test (WARNING)
  *   - Orphaned tests — itAssertion() calls referencing unknown IDs (WARNING)
  *   - Version drift (WARNING)
+ *
+ * Phase 3 additions:
+ *   - Behavioral coverage threshold enforcement (SPEC_BEHAVIORAL_THRESHOLD, default 80%)
+ *   - Contract coverage threshold enforcement (SPEC_CONTRACT_THRESHOLD, default 80%)
+ *   - --json flag for structured output (consumed by health report generator)
  */
 
 import * as fs from 'fs';
@@ -31,17 +37,43 @@ const BACKEND_SRC = path.join(ROOT, 'backend', 'src');
 const FRONTEND_SRC = path.join(ROOT, 'frontend', 'src');
 const TRACKER_PATH = path.join(ROOT, 'backend', 'src', '__tests__', 'helpers', 'spec-version-tracker.json');
 
+// --- CLI flags ---
+
+const args = process.argv.slice(2);
+const JSON_OUTPUT = args.includes('--json');
+
+// --- Coverage thresholds (env-configurable) ---
+
+const INVARIANT_THRESHOLD = 100; // Always 100% — non-negotiable
+const BEHAVIORAL_THRESHOLD = parseInt(process.env.SPEC_BEHAVIORAL_THRESHOLD || '80', 10);
+const CONTRACT_THRESHOLD = parseInt(process.env.SPEC_CONTRACT_THRESHOLD || '80', 10);
+
 // --- Types ---
 
 interface ScanResult {
   featureId: string;
   fileName: string;
   version: string;
+  status: string;
+  owner: string;
+  category: string;
   assertionCount: number;
   testedCount: number;
   untestedCount: number;
+  untestedIds: string[];
+  driftWarnings: string[];
   errors: string[];
   warnings: string[];
+  lastTested: string | null;
+  capabilities: CapabilitySummary[];
+}
+
+interface CapabilitySummary {
+  id: string;
+  version: string;
+  assertionCount: number;
+  testedCount: number;
+  hasDrift: boolean;
 }
 
 interface CoverageReport {
@@ -50,6 +82,26 @@ interface CoverageReport {
   invariants: { total: number; tested: number };
   behavioral: { total: number; tested: number };
   contracts: { total: number; tested: number };
+}
+
+interface ThresholdResult {
+  type: string;
+  threshold: number;
+  actual: number;
+  passed: boolean;
+  untested: string[];
+}
+
+/** Full structured output for --json mode and health report consumption */
+export interface ScanReport {
+  timestamp: string;
+  features: ScanResult[];
+  coverage: CoverageReport;
+  thresholds: ThresholdResult[];
+  orphanedTests: string[];
+  warnings: string[];
+  errors: string[];
+  passed: boolean;
 }
 
 // --- Helpers ---
@@ -117,19 +169,42 @@ function checkFileExists(filePath: string): boolean {
 
 // --- Main ---
 
-function scan(): void {
-  console.log('');
+function collectUntestedByType(
+  results: ScanResult[],
+  type: string,
+): string[] {
+  const freshTestedIds = extractTestedAssertionIds(findTestFiles());
+  const untested: string[] = [];
+  for (const r of results) {
+    const filePath = path.join(FEATURES_DIR, r.fileName);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const manifest = yaml.load(content) as FeatureManifest;
+    for (const cap of manifest.capabilities) {
+      for (const assertion of cap.assertions) {
+        if (assertion.type === type && !assertion.deprecated && !freshTestedIds.has(assertion.id)) {
+          untested.push(`${r.featureId}: ${assertion.id}`);
+        }
+      }
+    }
+  }
+  return untested;
+}
 
+function pct(tested: number, total: number): number {
+  return total > 0 ? Math.round((tested / total) * 100) : 100;
+}
+
+function scan(): ScanReport {
   // Load all manifests
   if (!fs.existsSync(FEATURES_DIR)) {
-    console.error('ERROR: specs/features/ directory does not exist');
+    if (!JSON_OUTPUT) console.error('ERROR: specs/features/ directory does not exist');
     process.exit(1);
   }
 
   const yamlFiles = fs.readdirSync(FEATURES_DIR).filter(f => f.endsWith('.feature.yaml'));
 
   if (yamlFiles.length === 0) {
-    console.log('No feature manifests found in specs/features/');
+    if (!JSON_OUTPUT) console.log('No feature manifests found in specs/features/');
     process.exit(0);
   }
 
@@ -161,38 +236,53 @@ function scan(): void {
     try {
       parsed = yaml.load(content);
     } catch (e) {
-      console.error(`ERROR: ${file} — YAML parse error: ${(e as Error).message}`);
+      if (!JSON_OUTPUT) console.error(`ERROR: ${file} — YAML parse error: ${(e as Error).message}`);
       hasErrors = true;
       continue;
     }
 
     const validationErrors: ValidationError[] = validateManifest(parsed);
     if (validationErrors.length > 0) {
-      console.error(`ERROR: ${file} — Schema validation failed:`);
-      for (const err of validationErrors) {
-        console.error(`  - [${err.path}] ${err.message}`);
+      if (!JSON_OUTPUT) {
+        console.error(`ERROR: ${file} — Schema validation failed:`);
+        for (const err of validationErrors) {
+          console.error(`  - [${err.path}] ${err.message}`);
+        }
       }
       hasErrors = true;
       continue;
     }
 
     const manifest = parsed as FeatureManifest;
+    const trackerRecord = tracker[manifest.feature];
     const result: ScanResult = {
       featureId: manifest.feature,
       fileName: file,
       version: manifest.version,
+      status: manifest.status,
+      owner: manifest.owner,
+      category: manifest.category,
       assertionCount: 0,
       testedCount: 0,
       untestedCount: 0,
+      untestedIds: [],
+      driftWarnings: [],
       errors: [],
       warnings: [],
+      lastTested: trackerRecord?.lastRun ?? null,
+      capabilities: [],
     };
-
-    // Check for duplicate feature IDs (across files)
-    // (validated by unique assertion IDs below)
 
     // Validate capabilities
     for (const cap of manifest.capabilities) {
+      const capSummary: CapabilitySummary = {
+        id: cap.id,
+        version: cap.version,
+        assertionCount: cap.assertions.length,
+        testedCount: 0,
+        hasDrift: false,
+      };
+
       // Check source file existence
       for (const f of cap.files) {
         if (!checkFileExists(f)) {
@@ -201,13 +291,13 @@ function scan(): void {
       }
 
       // Check version drift
-      const trackerRecord = tracker[manifest.feature];
       if (trackerRecord) {
         const lastCapVersion = trackerRecord.capabilities?.[cap.id];
         if (lastCapVersion && lastCapVersion !== cap.version) {
-          result.warnings.push(
-            `Version drift: ${cap.id} changed ${lastCapVersion} → ${cap.version}`,
-          );
+          capSummary.hasDrift = true;
+          const msg = `Version drift: ${cap.id} changed ${lastCapVersion} → ${cap.version}`;
+          result.warnings.push(msg);
+          result.driftWarnings.push(msg);
         }
       }
 
@@ -230,13 +320,17 @@ function scan(): void {
         // Check if tested
         if (testedIds.has(assertion.id)) {
           result.testedCount++;
+          capSummary.testedCount++;
           coverage.tested++;
           coverage[typeKey].tested++;
           testedIds.delete(assertion.id); // Remove so we can find orphaned tests later
         } else if (!assertion.deprecated) {
           result.untestedCount++;
+          result.untestedIds.push(assertion.id);
         }
       }
+
+      result.capabilities.push(capSummary);
     }
 
     // Validate AC mappings
@@ -252,62 +346,21 @@ function scan(): void {
     results.push(result);
   }
 
-  // --- Output ---
+  // Collect orphaned tests
+  const orphanedTests = [...testedIds];
 
-  const totalAssertions = results.reduce((sum, r) => sum + r.assertionCount, 0);
-  console.log(`Feature Spec Scanner — ${results.length} features, ${totalAssertions} assertions`);
-  console.log('');
-
-  for (const r of results) {
-    const icon = r.errors.length > 0 ? 'x' : r.untestedCount > 0 ? '!' : '+';
-    console.log(
-      `${icon} ${r.featureId} (v${r.version}) — ${r.assertionCount} assertions, ` +
-      `${r.testedCount} tested, ${r.untestedCount} untested`,
-    );
-  }
-
-  console.log('');
-  console.log(
-    `Coverage: ${coverage.tested}/${coverage.total} (${coverage.total > 0 ? Math.round((coverage.tested / coverage.total) * 100) : 0}%)`,
-  );
-  console.log(
-    `Invariants: ${coverage.invariants.tested}/${coverage.invariants.total} ` +
-    `(${coverage.invariants.total > 0 ? Math.round((coverage.invariants.tested / coverage.invariants.total) * 100) : 0}%)` +
-    (coverage.invariants.tested === coverage.invariants.total ? ' +' : ''),
-  );
-  console.log(
-    `Behavioral: ${coverage.behavioral.tested}/${coverage.behavioral.total} ` +
-    `(${coverage.behavioral.total > 0 ? Math.round((coverage.behavioral.tested / coverage.behavioral.total) * 100) : 0}%)`,
-  );
-  console.log(
-    `Contracts: ${coverage.contracts.tested}/${coverage.contracts.total} ` +
-    `(${coverage.contracts.total > 0 ? Math.round((coverage.contracts.tested / coverage.contracts.total) * 100) : 0}%)`,
-  );
-
-  // Warnings
+  // Collect all warnings
   const allWarnings: string[] = [];
   for (const r of results) {
     for (const w of r.warnings) {
       allWarnings.push(`${r.featureId}: ${w}`);
     }
   }
-
-  // Orphaned tests (itAssertion calls that don't match any manifest assertion)
-  if (testedIds.size > 0) {
-    for (const orphan of testedIds) {
-      allWarnings.push(`Orphaned test: itAssertion("${orphan}") has no matching manifest assertion`);
-    }
+  for (const orphan of orphanedTests) {
+    allWarnings.push(`Orphaned test: itAssertion("${orphan}") has no matching manifest assertion`);
   }
 
-  if (allWarnings.length > 0) {
-    console.log('');
-    console.log('Warnings:');
-    for (const w of allWarnings) {
-      console.log(`  - ${w}`);
-    }
-  }
-
-  // Errors
+  // Collect all errors
   const allErrors: string[] = [];
   for (const r of results) {
     for (const e of r.errors) {
@@ -315,50 +368,154 @@ function scan(): void {
     }
   }
 
-  if (allErrors.length > 0) {
+  // --- Phase 3: Coverage threshold enforcement ---
+
+  const thresholds: ThresholdResult[] = [];
+
+  // Invariants — always 100%
+  const untestedInvariants = coverage.invariants.tested < coverage.invariants.total
+    ? collectUntestedByType(results, 'invariant')
+    : [];
+  thresholds.push({
+    type: 'invariant',
+    threshold: INVARIANT_THRESHOLD,
+    actual: pct(coverage.invariants.tested, coverage.invariants.total),
+    passed: coverage.invariants.tested === coverage.invariants.total,
+    untested: untestedInvariants,
+  });
+
+  // Behavioral — configurable threshold (default 80%)
+  const behavioralPct = pct(coverage.behavioral.tested, coverage.behavioral.total);
+  const untestedBehavioral = behavioralPct < BEHAVIORAL_THRESHOLD
+    ? collectUntestedByType(results, 'behavioral')
+    : [];
+  thresholds.push({
+    type: 'behavioral',
+    threshold: BEHAVIORAL_THRESHOLD,
+    actual: behavioralPct,
+    passed: behavioralPct >= BEHAVIORAL_THRESHOLD,
+    untested: untestedBehavioral,
+  });
+
+  // Contracts — configurable threshold (default 80%)
+  const contractPct = pct(coverage.contracts.tested, coverage.contracts.total);
+  const untestedContracts = contractPct < CONTRACT_THRESHOLD
+    ? collectUntestedByType(results, 'contract')
+    : [];
+  thresholds.push({
+    type: 'contract',
+    threshold: CONTRACT_THRESHOLD,
+    actual: contractPct,
+    passed: contractPct >= CONTRACT_THRESHOLD,
+    untested: untestedContracts,
+  });
+
+  const allThresholdsPassed = thresholds.every(t => t.passed);
+  const passed = !hasErrors && allThresholdsPassed;
+
+  const report: ScanReport = {
+    timestamp: new Date().toISOString(),
+    features: results,
+    coverage,
+    thresholds,
+    orphanedTests,
+    warnings: allWarnings,
+    errors: allErrors,
+    passed,
+  };
+
+  // --- Output ---
+
+  if (JSON_OUTPUT) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
     console.log('');
-    console.log('Errors:');
-    for (const e of allErrors) {
-      console.log(`  - ${e}`);
-    }
-  }
+    const totalAssertions = results.reduce((sum, r) => sum + r.assertionCount, 0);
+    console.log(`Feature Spec Scanner — ${results.length} features, ${totalAssertions} assertions`);
+    console.log('');
 
-  console.log('');
-
-  if (hasErrors) {
-    console.error('FAILED — Fix errors above before proceeding.');
-    process.exit(1);
-  }
-
-  // Phase 2: Invariant coverage enforcement
-  // All invariant assertions MUST have tests
-  if (coverage.invariants.tested < coverage.invariants.total) {
-    // Re-extract all tested IDs (fresh scan since testedIds was mutated above)
-    const freshTestedIds = extractTestedAssertionIds(findTestFiles());
-    const untestedInvariants: string[] = [];
     for (const r of results) {
-      const filePath = path.join(FEATURES_DIR, r.fileName);
-      const content = fs.readFileSync(filePath, 'utf-8');
-      const manifest = yaml.load(content) as FeatureManifest;
-      for (const cap of manifest.capabilities) {
-        for (const assertion of cap.assertions) {
-          if (assertion.type === 'invariant' && !assertion.deprecated && !freshTestedIds.has(assertion.id)) {
-            untestedInvariants.push(`${r.featureId}: ${assertion.id}`);
-          }
+      const icon = r.errors.length > 0 ? 'x' : r.untestedCount > 0 ? '!' : '+';
+      console.log(
+        `${icon} ${r.featureId} (v${r.version}) — ${r.assertionCount} assertions, ` +
+        `${r.testedCount} tested, ${r.untestedCount} untested`,
+      );
+    }
+
+    console.log('');
+    console.log(`Coverage: ${coverage.tested}/${coverage.total} (${pct(coverage.tested, coverage.total)}%)`);
+    console.log(
+      `Invariants: ${coverage.invariants.tested}/${coverage.invariants.total} ` +
+      `(${pct(coverage.invariants.tested, coverage.invariants.total)}%)` +
+      (coverage.invariants.tested === coverage.invariants.total ? ' +' : ''),
+    );
+    console.log(
+      `Behavioral: ${coverage.behavioral.tested}/${coverage.behavioral.total} ` +
+      `(${behavioralPct}%)` +
+      (behavioralPct >= BEHAVIORAL_THRESHOLD ? ' +' : ` [threshold: ${BEHAVIORAL_THRESHOLD}%]`),
+    );
+    console.log(
+      `Contracts: ${coverage.contracts.tested}/${coverage.contracts.total} ` +
+      `(${contractPct}%)` +
+      (contractPct >= CONTRACT_THRESHOLD ? ' +' : ` [threshold: ${CONTRACT_THRESHOLD}%]`),
+    );
+
+    // Thresholds summary
+    console.log('');
+    console.log('Thresholds:');
+    for (const t of thresholds) {
+      const icon = t.passed ? '+' : 'x';
+      console.log(`  ${icon} ${t.type}: ${t.actual}% (min ${t.threshold}%)`);
+    }
+
+    if (allWarnings.length > 0) {
+      console.log('');
+      console.log('Warnings:');
+      for (const w of allWarnings) {
+        console.log(`  - ${w}`);
+      }
+    }
+
+    if (allErrors.length > 0) {
+      console.log('');
+      console.log('Errors:');
+      for (const e of allErrors) {
+        console.log(`  - ${e}`);
+      }
+    }
+
+    // Threshold failures
+    for (const t of thresholds) {
+      if (!t.passed && t.untested.length > 0) {
+        console.log('');
+        console.log(`Untested ${t.type}s (BLOCKING — threshold ${t.threshold}%, actual ${t.actual}%):`);
+        for (const id of t.untested) {
+          console.log(`  - ${id}`);
         }
       }
     }
-    if (untestedInvariants.length > 0) {
-      console.log('Untested invariants (BLOCKING):');
-      for (const inv of untestedInvariants) {
-        console.log(`  - ${inv}`);
-      }
-      console.error(`\nFAILED — ${untestedInvariants.length} invariant assertion(s) have no tests. All invariants must be covered.`);
-      process.exit(1);
-    }
+
+    console.log('');
   }
 
-  console.log('PASSED — All feature manifests are valid. Invariant coverage: 100%.');
+  if (hasErrors) {
+    if (!JSON_OUTPUT) console.error('FAILED — Fix errors above before proceeding.');
+    process.exit(1);
+  }
+
+  if (!allThresholdsPassed) {
+    const failedTypes = thresholds.filter(t => !t.passed).map(t => `${t.type} (${t.actual}% < ${t.threshold}%)`);
+    if (!JSON_OUTPUT) {
+      console.error(`FAILED — Coverage thresholds not met: ${failedTypes.join(', ')}`);
+    }
+    process.exit(1);
+  }
+
+  if (!JSON_OUTPUT) {
+    console.log('PASSED — All feature manifests valid. All coverage thresholds met.');
+  }
+
+  return report;
 }
 
 scan();

--- a/specs/_SPEC_INDEX.md
+++ b/specs/_SPEC_INDEX.md
@@ -83,11 +83,23 @@ Structured YAML manifests that link specs → assertions → tests. See `plans/2
 | `specs/features/_schema.ts` | TypeScript types and validation for YAML manifests |
 | `specs/features/registry.ts` | Manifest loader, validator, and indexer |
 | `backend/src/__tests__/helpers/feature-spec.ts` | Test helpers: `describeFeature()`, `itAssertion()` |
-| `scripts/scan-feature-specs.ts` | CI scanner: validate, coverage, drift detection |
+| `scripts/scan-feature-specs.ts` | CI scanner: validate, coverage, drift, threshold enforcement |
+| `scripts/feature-health-report.ts` | Health report generator: PR comments and dashboard |
+| `.github/workflows/feature-specs.yml` | CI workflow: validate + auto-post PR coverage report |
 
 **Commands**:
-- `npm run validate:specs` — Run the feature spec scanner
+- `npm run validate:specs` — Validate manifests and enforce coverage thresholds
+- `npm run validate:specs:json` — Same as above but JSON output (for tooling)
+- `npm run report:specs` — Generate PR comment markdown (coverage summary)
+- `npm run report:specs:dashboard` — Generate full health dashboard markdown
 - Assertion types: `invariant` (must always hold) · `behavioral` (may evolve) · `contract` (interface boundary)
+
+**Coverage Thresholds** (Phase 3):
+| Type | Threshold | Configurable via |
+|------|-----------|------------------|
+| Invariant | 100% (non-negotiable) | — |
+| Behavioral | 80% (default) | `SPEC_BEHAVIORAL_THRESHOLD` env var |
+| Contract | 80% (default) | `SPEC_CONTRACT_THRESHOLD` env var |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Phase 3 (Maturity)** of the living feature specs system is complete
- Scanner now enforces configurable behavioral (80%) and contract (80%) coverage thresholds alongside the existing 100% invariant gate
- New `--json` flag on the scanner provides structured output for tooling
- New `feature-health-report.ts` generates markdown reports in two modes: concise PR comment (`--pr`) and full health dashboard (`--dashboard`) with A+ through D grading
- GitHub Actions workflow (`feature-specs.yml`) validates specs on PRs and auto-posts/updates a coverage report comment
- New npm scripts: `validate:specs:json`, `report:specs`, `report:specs:dashboard`
- Updated `_SPEC_INDEX.md` and plan document to reflect Phase 3 completion

## Test plan
- [x] `npm run validate:specs` passes — 6 features, 103/103 assertions, all thresholds met
- [x] `npm run validate:specs:json` produces valid structured JSON
- [x] `npm run report:specs` generates PR comment markdown with per-feature table
- [x] `npm run report:specs:dashboard` generates full health dashboard with capability breakdown
- [x] All 426 tests pass (291 backend + 135 frontend)
- [x] TypeScript typecheck clean across all packages
- [x] Lint clean (0 errors, 0 warnings)
- [x] Threshold enforcement verified: scanner exits non-zero when coverage drops below configured minimums