### PR TITLE
fix: resolve seed.dev.ts TypeScript errors on Node 23+

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "dev:simple:setup": "npm run dev:simple:generate && npm run dev:simple:migrate && npm run dev:simple:seed",
     "dev:simple:generate": "rm -rf node_modules/.prisma && cp prisma/schema.dev.prisma prisma/schema.prisma && prisma generate",
     "dev:simple:migrate": "rm -f prisma/dev.db && prisma db push --schema=prisma/schema.dev.prisma --accept-data-loss --force-reset",
-    "dev:simple:seed": "ts-node prisma/seed.dev.ts",
+    "dev:simple:seed": "ts-node --project tsconfig.seed.json prisma/seed.dev.ts",
     "build": "tsc && tsc-alias",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -26,7 +26,7 @@
     "db:studio": "prisma studio"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node --project tsconfig.seed.json prisma/seed.ts"
   },
   "keywords": [
     "testops",

--- a/backend/prisma/seed.dev.ts
+++ b/backend/prisma/seed.dev.ts
@@ -10,7 +10,7 @@
  * Uses a comprehensive seeding approach with Faker for realistic demo data.
  */
 
-import { PrismaClient, Prisma, Pipeline } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 import * as crypto from 'crypto';
 import * as bcrypt from 'bcrypt';
@@ -205,7 +205,7 @@ async function seed() {
 
   // ── 3. Pipelines ──
   console.log('Creating pipelines...');
-  const pipelines: Pipeline[] = [];
+  const pipelines: Array<{ id: string; name: string; [k: string]: any }> = [];
   for (const tpl of PIPELINE_TEMPLATES) {
     const pipeline = await prisma.pipeline.create({
       data: {
@@ -641,7 +641,14 @@ async function seed() {
 
   // ── 16. TestRail Runs ──
   console.log('Creating TestRail runs...');
-  const testRailPayloads: Prisma.TestRailRunCreateManyInput[] = [];
+  const testRailPayloads: Array<{
+    testRailRunId: number;
+    projectId: number;
+    suiteId: number;
+    name: string;
+    description: string;
+    testRunId: string | null;
+  }> = [];
   for (let i = 1; i <= 10; i++) {
     testRailPayloads.push({
       testRailRunId: 1000 + i,


### PR DESCRIPTION
ts-node v10 with Node 23's module loading changes causes some Prisma re-exported types (Pipeline, TestRailRunCreateManyInput) to resolve as `never`. Two fixes:

1. Point ts-node at tsconfig.seed.json (which already existed but was never wired up) — sets rootDir to "." and includes prisma/**/*
2. Replace imported Prisma model types with inline type literals so the seed script doesn't depend on ts-node correctly resolving the @prisma/client → .prisma/client/default re-export chain

Verified: `npm run dev:simple:setup` completes successfully and seeds 26,600+ data points.
