### PR TITLE
fix(e2e): resolve 14/15 Playwright test failures

### DIFF
--- a/tests/e2e/ai-write-flow.spec.ts
+++ b/tests/e2e/ai-write-flow.spec.ts
@@ -1,39 +1,35 @@
-
 import { test, expect } from '@playwright/test';
+import {
+    setupAuthenticatedSession,
+    mockChatSSE,
+    mockConfirmAction,
+    SCENARIO_JIRA_CREATE,
+} from './fixtures/mock-api';
 
 test('AI Write Tool Confirmation Flow', async ({ page }) => {
-    // 1. Login
-    await page.goto('/login');
-    await page.fill('input[name="email"]', 'engineer@testops.ai');
-    await page.fill('input[name="password"]', 'demo123');
-    await page.click('button[type="submit"]');
-    await expect(page).toHaveURL('/dashboard');
+    await setupAuthenticatedSession(page);
+    await mockChatSSE(page, SCENARIO_JIRA_CREATE);
+    await mockConfirmAction(page, false);
 
-    // 2. Open Copilot (Click the Sparkle FAB)
-    // The FAB is an IconButton with the SparkleIcon (AutoAwesome)
-    const fab = page.locator('button').filter({ has: page.locator('svg[data-testid="AutoAwesomeIcon"]') });
-    await expect(fab).toBeVisible();
-    await fab.click();
+    await page.goto('/dashboard');
 
-    // 3. Trigger write action
-    const input = page.getByPlaceholder('Ask Copilot...');
+    // Trigger write action via copilot chat
+    const input = page.locator('textarea[placeholder="Ask Copilot..."]');
     await expect(input).toBeVisible();
     await input.fill('Create a Jira bug: "E2E Test Failure"');
     await input.press('Enter');
 
-    // 4. Wait for confirmation card
-    // New MUI implementation says "APPROVAL REQUIRED" in a Typography
+    // Wait for confirmation card
     const confirmationCard = page.locator('.MuiPaper-root').filter({ hasText: 'APPROVAL REQUIRED' }).first();
     await expect(confirmationCard).toBeVisible({ timeout: 10000 });
 
-    // Verify tool args are visible (Payload Preview)
-    await expect(confirmationCard).toContainText('E2E Test Failure');
+    // Verify tool args are visible
+    await expect(confirmationCard).toContainText('Login Timeout Fix');
 
-    // 5. Deny Action first
-    await confirmationCard.getByRole('button', { name: 'Deny' }).click();
+    // Deny Action
+    await confirmationCard.getByRole('button', { name: /deny/i }).click();
 
-    // 6. Verify status update
-    // The previous locator relied on 'APPROVAL REQUIRED', which is replaced by 'ACTION DENIED'
+    // Verify status update
     const deniedCard = page.locator('.MuiPaper-root').filter({ hasText: 'ACTION DENIED' }).first();
-    await expect(deniedCard).toBeVisible();
+    await expect(deniedCard).toBeVisible({ timeout: 5000 });
 });

--- a/tests/e2e/fixtures/mock-api.ts
+++ b/tests/e2e/fixtures/mock-api.ts
@@ -383,8 +383,10 @@ export async function setupAuthenticatedSession(page: Page): Promise<void> {
   await mockAuthAPIs(page);
   await mockDashboardAPIs(page);
 
-  // Pre-set the access token so AuthContext picks it up
+  // Pre-set the access token and onboarding flag so AuthContext picks it up
+  // and the OnboardingWizard modal doesn't block dashboard interaction
   await page.addInitScript(() => {
     localStorage.setItem('accessToken', 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e2e-test-token');
+    localStorage.setItem('onboardingComplete', 'true');
   });
 }

--- a/tests/e2e/sanity.spec.ts
+++ b/tests/e2e/sanity.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { setupAuthenticatedSession } from './fixtures/mock-api';
 
 test('has title', async ({ page }) => {
     await page.goto('/');
@@ -8,27 +9,12 @@ test('has title', async ({ page }) => {
 });
 
 test('loads dashboard and shows metrics', async ({ page }) => {
-    await page.goto('/');
-
-    // Verify critical dashboard elements are present
-    // Note: Selectors might need adjustment based on actual frontend implementation
-    // Looking for general structure first
+    await setupAuthenticatedSession(page);
+    await page.goto('/dashboard');
 
     // Wait for main layout
     await expect(page.locator('#root')).toBeVisible();
 
     // Wait for some content to load
     await expect(page.getByText('TestOps Companion')).toBeVisible();
-
-    // Check for navigation sidebar or header
-    // Assuming standard layout elements based on typical React apps
-    // We'll improve selectors after first run failure/inspection if needed
-    // But searching for text is usually robust for sanity
-    const appTitle = page.getByText('TestOps Companion');
-    await expect(appTitle).toBeVisible();
-
-    // Check for specific dashboard metrics or headers
-    // E.g., "Pipeline Health", "Test Runs", etc.
-    // Using generic text matchers for flexibility
-    // await expect(page.getByText(/Pipeline Health/i)).toBeVisible(); // Commented out until verified content
 });


### PR DESCRIPTION
root causes, all in the test infrastructure (not application code):
1. OnboardingWizard modal blocked all copilot interaction (12 tests)
setupAuthenticatedSession() in mock-api.ts set localStorage.accessToken but forgot to set onboardingComplete. When the dashboard loaded, Layout.tsx:92 saw no onboardingComplete flag and opened the <OnboardingWizard> as a MUI Dialog modal. The modal trapped focus and intercepted all clicks, so every test that tried to .fill() or .click() the chat textarea timed out.
Fix: Added localStorage.setItem('onboardingComplete', 'true') to the fixture.
2. sanity.spec.ts had no auth mocks (1 test)
The “loads dashboard” test navigated to / without any authentication. ProtectedRoute redirected to /login. The test expected dashboard content that never appeared.
Fix: Added setupAuthenticatedSession() call.
3. ai-write-flow.spec.ts had zero mocks (1 test)
This test filled the login form and clicked submit with no Playwright route interceptors. The POST went through Vite’s proxy to http://localhost:4000 (backend) — which isn’t running during E2E tests (Playwright only starts the frontend). Network error, timeout.
Fix: Rewrote to use the shared mock fixtures from mock-api.ts.