### PR TITLE
fix: enable AI services in demo mode, fix E2E route ordering, add Giphy

### DIFF
--- a/backend/src/__tests__/helpers/spec-version-tracker.json
+++ b/backend/src/__tests__/helpers/spec-version-tracker.json
@@ -8,7 +8,7 @@
       "housekeeping.suggestion": "1.0.0",
       "housekeeping.undo": "1.0.0"
     },
-    "lastRun": "2026-02-21T22:22:13.939Z"
+    "lastRun": "2026-02-22T04:53:16.047Z"
   },
   "resilience": {
     "lastTestedVersion": "1.0.0",
@@ -18,7 +18,7 @@
       "resilience.timeout": "1.0.0",
       "resilience.preconfigured": "1.0.0"
     },
-    "lastRun": "2026-02-21T22:50:15.683Z"
+    "lastRun": "2026-02-22T04:53:16.463Z"
   },
   "authentication": {
     "lastTestedVersion": "1.0.0",
@@ -68,5 +68,27 @@
       "giphy.autonomy": "1.0.0"
     },
     "lastRun": "2026-02-21T22:22:13.898Z"
+  },
+  "autonomy-preferences": {
+    "lastTestedVersion": "1.0.0",
+    "capabilities": {
+      "autonomy.classifier": "1.0.0",
+      "autonomy.context-overrides": "1.0.0",
+      "autonomy.user-preference": "1.0.0",
+      "autonomy.gated-check": "1.0.0",
+      "autonomy.frontend": "1.0.0",
+      "autonomy.api": "1.0.0"
+    },
+    "lastRun": "2026-02-22T04:53:15.994Z"
+  },
+  "react-loop": {
+    "lastTestedVersion": "1.0.0",
+    "capabilities": {
+      "react.loop": "1.0.0",
+      "react.tools": "1.0.0",
+      "react.streaming": "1.0.0",
+      "react.tools-registry": "1.0.0"
+    },
+    "lastRun": "2026-02-22T04:53:16.182Z"
   }
 }

--- a/backend/src/services/ai/mock-tool-results.ts
+++ b/backend/src/services/ai/mock-tool-results.ts
@@ -228,6 +228,7 @@ const giphySearch: MockResultFn = (args) => ({
         selected: { id: 'gif-001', title: 'Celebration Dance', url: 'https://media.giphy.com/media/example1/giphy.gif', thumbnailUrl: 'https://media.giphy.com/media/example1/100w.gif', width: 200, height: 150, giphyUrl: 'https://giphy.com/gifs/example1' },
         query: args.query || 'celebration',
         attribution: 'Powered by GIPHY',
+        fallbackEmoji: '🎉',
     },
 });
 

--- a/backend/src/services/ai/providers/mock.provider.ts
+++ b/backend/src/services/ai/providers/mock.provider.ts
@@ -3,7 +3,7 @@
  *
  * Returns native toolCalls matching realistic user intents so the
  * complete card experience renders without a real LLM or external APIs.
- * Covers all 18 registered tools across 8 services.
+ * Covers all 22 registered tools across 8 services.
  */
 
 import { BaseProvider, ProviderConfig, ProviderLimits, ProviderPricing, CompletionOptions, EmbeddingOptions } from './base.provider';
@@ -65,6 +65,11 @@ const INTENT_RULES: IntentRule[] = [
     { primary: ['testops-', 'proj-', 'jira-', 'issue key', 'get issue', 'show issue', 'get ticket'],
       tool: 'jira_get', args: { issueKey: 'TESTOPS-142' },
       preamble: 'Retrieving the issue details.' },
+
+    // Giphy — celebratory / fun personality layer (Sprint 7, housekeeping tier)
+    { primary: ['gif', 'giphy', 'celebrate', 'celebration', 'meme', 'fun', 'party', 'hooray', 'woohoo'],
+      tool: 'giphy_search', args: { query: 'celebration' },
+      preamble: 'Let me find a fun GIF for that!' },
 
     // ── Write tools (Phase 2) — these trigger confirmation previews ──
 
@@ -162,6 +167,7 @@ const TOOL_SUMMARIES: Record<string, string> = {
     testrun_cancel: 'Test run cancelled successfully. The run has been marked as CANCELLED.',
     testrun_retry: 'Retrying the failed test run. A new run has been queued as PENDING.',
     github_rerun_workflow: 'GitHub Actions workflow `ci.yml` has been re-triggered on `main`. It should start shortly.',
+    giphy_search: 'Here\'s a celebratory GIF! Enjoy the moment.',
 };
 
 // ─── Provider ───

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -24,6 +24,8 @@ These are the distilled "never again" rules from every incident below. **Read th
 | Never assume CI environments have the same env vars as local dev | Missing `REDIS_URL` or `AI_ENABLED` causes test failures invisible locally | EPR-009 |
 | Never mix setup and server start in one concurrent command | If setup fails, the concurrent server processes mask the error | EPR-010 |
 | Never use `ts-node` for seed/script execution on Node 23+ | `ts-node` v10 misresolves Prisma re-exported types; use `tsx` | EPR-011 |
+| Never register a Playwright catch-all route after specific routes | LIFO order means catch-all evaluates first, hijacking all requests | EPR-012 |
+| Never ship demo mode with core features disabled in generated .env | `AI_ENABLED=false` in deploy-demo.sh disables the entire AI copilot | EPR-013 |
 
 ---
 
@@ -204,6 +206,34 @@ JWT_SECRET=<any value for tests>
 | **CI guard** | `deploy-demo.sh` uses `tsx` for seed execution; if compilation fails, `set -e` kills the script |
 | **Status** | **Mitigated** (Sprint 7) |
 
+### EPR-012: Playwright Route Ordering (LIFO Catch-All Trap)
+
+| Field | Value |
+|-------|-------|
+| **Pattern** | Catch-all `page.route('**/api/v1/**')` registered LAST in `mockDashboardAPIs()` evaluates FIRST due to Playwright's LIFO (last-in-first-out) handler order — intercepts ALL requests before specific handlers (auth, dashboard, chat) can fire |
+| **First seen** | Sprint 7 (2026-02-22) |
+| **Impact** | P1 — 13/15 E2E tests fail. GET `/auth/me` returns `{ data: [] }` instead of user object → auth fails → redirect to /login. POST `/auth/login` calls `route.continue()` → network → ECONNREFUSED |
+| **Root cause** | `mockDashboardAPIs()` registered specific routes first, then a catch-all last. Playwright evaluates handlers in reverse registration order (LIFO), so the catch-all ran first for every request, shadowing all specific handlers |
+| **Fix** | Register catch-all FIRST in `setupAuthenticatedSession()` (so it evaluates LAST in LIFO), then register specific routes after (so they evaluate FIRST) |
+| **Prevention** | Always register Playwright catch-all/fallback routes BEFORE specific routes. Add a comment explaining LIFO evaluation. Consider using `route.fallback()` for pass-through patterns |
+| **CI guard** | E2E test suite (`npx playwright test`) — all 15 tests must pass |
+| **Status** | **Mitigated** (Sprint 7) |
+
+---
+
+### EPR-013: Demo Mode Feature Flags (AI Disabled in Generated .env)
+
+| Field | Value |
+|-------|-------|
+| **Pattern** | `deploy-demo.sh` generates `backend/.env` with `AI_ENABLED=false`, disabling the entire AI copilot in demo mode. The mock provider exists and works correctly, but `AIChatService.handleChatStream()` short-circuits before reaching it |
+| **First seen** | Sprint 7 (2026-02-22) |
+| **Impact** | P1 — Copilot shows "AI services are not initialized or enabled" for every query. No tool cards rendered, no Giphy, no agentic workflow visible. Demo mode is fundamentally broken |
+| **Root cause** | The demo script was written conservatively with `AI_ENABLED=false` to avoid API key errors. But the mock provider (`AI_PROVIDER=mock`) doesn't need API keys and is specifically designed for demo mode |
+| **Fix** | Changed `deploy-demo.sh` to generate `AI_ENABLED=true`, `AI_PROVIDER=mock`, `AI_MODEL=mock` in the .env file |
+| **Prevention** | Demo script must enable mock provider. Smoke test after deploy: verify copilot responds with tool cards. Add `GIPHY_ENABLED=true` for full demo experience |
+| **CI guard** | Deploy-demo smoke test should verify copilot functionality (not just server start) |
+| **Status** | **Mitigated** (Sprint 7) |
+
 ---
 
 ## Automated Guards Summary
@@ -236,6 +266,8 @@ Before starting each sprint, the Release QA Engineer verifies:
 - [ ] CI workflow env vars match the Required CI Environment Variables list (EPR-009)
 - [ ] `npm run deploy:demo` completes successfully from a clean state (EPR-010)
 - [ ] Seed scripts use `tsx` (not `ts-node`) for Node 23+ compatibility (EPR-011)
+- [ ] E2E Playwright catch-all routes are registered BEFORE specific routes (EPR-012)
+- [ ] `deploy-demo.sh` generates `.env` with `AI_ENABLED=true` and `AI_PROVIDER=mock` (EPR-013)
 - [ ] Tech debt tracker in `ROADMAP.md` is current
 - [ ] This document has been reviewed for new patterns from the previous sprint
 
@@ -257,5 +289,5 @@ Per semver and the `RELEASE_QA_ENGINEER.md` version strategy:
 
 ---
 
-*Last updated: 2026-02-21 (Sprint 7)*
+*Last updated: 2026-02-22 (Sprint 7)*
 *Next review: Start of Sprint 8*

--- a/frontend/src/components/AICopilot/cards/GiphyEmbedCard.tsx
+++ b/frontend/src/components/AICopilot/cards/GiphyEmbedCard.tsx
@@ -39,6 +39,7 @@ interface GiphyEmbedCardProps {
 export default function GiphyEmbedCard({ data }: GiphyEmbedCardProps) {
     const giphyData = data as unknown as GiphyData;
     const [dismissed, setDismissed] = useState(false);
+    const [imgError, setImgError] = useState(false);
 
     // If dismissed, show nothing
     if (dismissed) return null;
@@ -57,6 +58,39 @@ export default function GiphyEmbedCard({ data }: GiphyEmbedCardProps) {
     const aspectRatio = gif.width / gif.height;
     const displayWidth = Math.min(200, gif.width);
     const displayHeight = displayWidth / aspectRatio;
+
+    // Image failed to load (e.g. mock URLs in demo mode) — show emoji fallback
+    if (imgError) {
+        const emoji = giphyData.fallbackEmoji || '🎉';
+        return (
+            <Paper
+                sx={{
+                    mb: 1.5,
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                    display: 'inline-block',
+                    maxWidth: 220,
+                    border: 1,
+                    borderColor: 'divider',
+                    textAlign: 'center',
+                    py: 2,
+                    px: 3,
+                }}
+            >
+                <Box sx={{ fontSize: '2.5rem', mb: 0.5 }} role="img" aria-label={gif.title}>
+                    {emoji}
+                </Box>
+                <Typography variant="caption" color="text.secondary" display="block">
+                    {gif.title}
+                </Typography>
+                <Box sx={{ px: 1, py: 0.25, mt: 0.5 }}>
+                    <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.55rem' }}>
+                        {giphyData.attribution}
+                    </Typography>
+                </Box>
+            </Paper>
+        );
+    }
 
     return (
         <Paper
@@ -90,12 +124,13 @@ export default function GiphyEmbedCard({ data }: GiphyEmbedCardProps) {
                     <CloseIcon sx={{ fontSize: 12 }} />
                 </IconButton>
 
-                {/* GIF image */}
+                {/* GIF image — falls back to emoji card on load error */}
                 <Box
                     component="img"
                     src={gif.url}
                     alt={gif.title}
                     loading="lazy"
+                    onError={() => setImgError(true)}
                     sx={{
                         display: 'block',
                         width: displayWidth,

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -76,7 +76,10 @@ JWT_SECRET=${JWT_SECRET}
 JWT_REFRESH_SECRET=${JWT_REFRESH}
 JWT_EXPIRES_IN=24h
 JWT_REFRESH_EXPIRES_IN=7d
-AI_ENABLED=false
+AI_ENABLED=true
+AI_PROVIDER=mock
+AI_MODEL=mock
+GIPHY_ENABLED=true
 CORS_ORIGIN=http://localhost:5173
 EOF
     echo -e "  Created backend/.env (demo config)"

--- a/tests/e2e/fixtures/mock-api.ts
+++ b/tests/e2e/fixtures/mock-api.ts
@@ -127,7 +127,7 @@ export async function mockDashboardAPIs(page: Page): Promise<void> {
     });
   });
 
-  // AI cost tracking
+  // AI cost tracking (usage)
   await page.route('**/api/v1/ai/usage**', async (route) => {
     await route.fulfill({
       status: 200,
@@ -136,19 +136,26 @@ export async function mockDashboardAPIs(page: Page): Promise<void> {
     });
   });
 
-  // Catch-all for other API routes to prevent 404s
-  await page.route('**/api/v1/**', async (route) => {
-    // Only intercept GET requests that haven't been handled above
-    if (route.request().method() === 'GET') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ data: [] }),
-      });
-    } else {
-      await route.continue();
-    }
+  // AI cost tracking (costs — used by QuotaIndicator)
+  await page.route('**/api/v1/ai/costs**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          totalCost: 42.50,
+          monthlySpent: 42.50,
+          monthlyBudget: 200,
+          cacheSavings: 8.20,
+          cacheHitRate: 0.34,
+        },
+      }),
+    });
   });
+
+  // NOTE: The API catch-all route is registered in setupAuthenticatedSession()
+  // BEFORE these specific routes, so Playwright's LIFO evaluation ensures
+  // specific routes fire first and the catch-all only handles unmatched URLs.
 }
 
 // ─── SSE Chat Mock Helpers ───────────────────────────────────────────
@@ -378,13 +385,29 @@ export async function mockConfirmAction(page: Page, approved: boolean): Promise<
 /**
  * Sets up all API mocks and logs the user in.
  * After calling this, the page will be at /dashboard with a logged-in user.
+ *
+ * IMPORTANT — Playwright route ordering (LIFO):
+ * Handlers run in REVERSE registration order. The catch-all is registered
+ * FIRST so it evaluates LAST (as a fallback). Specific routes registered
+ * AFTER take priority because they evaluate FIRST.
  */
 export async function setupAuthenticatedSession(page: Page): Promise<void> {
+  // 1. Catch-all FIRST — Playwright LIFO means this evaluates LAST (fallback)
+  //    Prevents unmatched API routes from hitting the Vite proxy (no backend running)
+  await page.route('**/api/v1/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    });
+  });
+
+  // 2. Specific routes AFTER — Playwright LIFO means these evaluate FIRST
   await mockAuthAPIs(page);
   await mockDashboardAPIs(page);
 
-  // Pre-set the access token and onboarding flag so AuthContext picks it up
-  // and the OnboardingWizard modal doesn't block dashboard interaction
+  // 3. Pre-set the access token and onboarding flag so AuthContext picks it up
+  //    and the OnboardingWizard modal doesn't block dashboard interaction
   await page.addInitScript(() => {
     localStorage.setItem('accessToken', 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e2e-test-token');
     localStorage.setItem('onboardingComplete', 'true');


### PR DESCRIPTION
Three root causes found and fixed:

1. deploy-demo.sh generated AI_ENABLED=false — copilot showed "AI services are not initialized" for every query. Changed to AI_ENABLED=true with AI_PROVIDER=mock so mock provider handles all tool calls without needing API keys.

2. Playwright catch-all route registered LAST in mockDashboardAPIs() evaluated FIRST due to LIFO ordering — hijacked all requests before specific auth/dashboard handlers could fire. Moved catch-all to register FIRST in setupAuthenticatedSession() so it evaluates LAST as a fallback. Added /ai/costs mock for QuotaIndicator.

3. Mock provider had no giphy_search intent — added intent rule + wrap-up summary. Added onError fallback to GiphyEmbedCard so mock URLs gracefully degrade to emoji card.

Lessons learned: EPR-012 (Playwright LIFO trap), EPR-013 (demo mode feature flags).

417/417 backend + 135/135 frontend tests pass, zero TS errors.