### PR TITLE
fix(security): remove .env.dev from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ out/
 # Environment variables
 .env
 .env.local
+.env.dev
 .env.development.local
 .env.test.local
 .env.production.local

--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -1,5 +1,6 @@
 # Development Mode Environment Variables (SQLite)
-# This file is used for demo mode with SQLite database
+# Copy this file to .env.dev:  cp .env.dev.example .env.dev
+# .env.dev is gitignored — your local copy won't be committed.
 
 # Database (SQLite - no Docker needed!)
 DATABASE_URL="file:./prisma/dev.db"
@@ -30,7 +31,6 @@ GOOGLE_API_KEY=demo-key
 
 # AI Configuration
 AI_ENABLED=true
-# AI_PROVIDER=openai
 AI_PROVIDER=mock
 AI_MODEL=mock
 AI_FEATURE_RCA_MATCHING=true

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -2,7 +2,8 @@ import dotenv from 'dotenv';
 import { z } from 'zod';
 
 // Load environment variables.
-// Fallback chain: .env (user/production overrides) > .env.dev (checked-in dev defaults).
+// Fallback chain: .env (user/production overrides) > .env.dev (local dev defaults, gitignored).
+// New devs: cp .env.dev.example .env.dev to get started.
 // dotenv v16+ processes the array in order; first file's values win for any given key.
 // Real environment variables (Docker, CI) always take precedence over file values.
 dotenv.config({ path: ['.env', '.env.dev'] });


### PR DESCRIPTION
## Summary
- Removes `backend/.env.dev` from version control (was tracked with dev secrets)
- Adds `.env.dev` to root `.gitignore`
- Creates `backend/.env.dev.example` as a copy-paste template for new developers
- Updates `config.ts` comment to document the new setup

## Why
`.env.dev` contained dev-mode JWT secrets and API key placeholders. While only dev values, tracking env files in git is a bad practice — triggers secret-scanning tools and sets a precedent for accidentally committing real secrets.

## Developer workflow (unchanged)
```bash
cd backend
cp .env.dev.example .env.dev   # one-time setup
npm run dev                     # dotenv loads .env > .env.dev fallback chain
```

## What's NOT in this PR
History rewrite (`git filter-repo`) — can be done separately if needed. This PR uses the safe `git rm --cached` approach.

## Remediation plan ref
Phase 1.2 — H2 from internal audit (`plans/2026-02-23-unified-remediation-plan.md`)

## Test plan
- [x] `backend/.env.dev` is gitignored: `git check-ignore backend/.env.dev` returns match
- [x] Local `.env.dev` file still exists (not deleted from disk)
- [x] Full backend suite: 30 suites, 488 tests passing
- [x] TypeScript typecheck clean
- [x] dotenv fallback chain still works (config.ts loads `.env` > `.env.dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)