### PR TITLE
chore(release): v3.0.0 GA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > This file is the **single entrypoint** for all AI coding agents working in this repo.
 > It defines how AI should reason about this codebase, what to prioritize, and how to collaborate.
 >
-> **Version**: 3.0.0-rc.4 | **Updated**: 2026-02-26
+> **Version**: 3.0.0 | **Updated**: 2026-02-26
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,86 @@ Beta releases are pre-release builds on the path to production GA.
 
 ---
 
+## [3.0.0] - 2026-02-26
+
+> **TestOps Companion v3.0.0 — General Availability**
+
+### The Release
+
+Four release candidates. 760 tests. 16 spec'd features with 229 assertions. A full security audit. And now: GA.
+
+TestOps Companion v3 is an AI-powered test operations platform where an agentic copilot — backed by a virtual team of 9 specialist personas — investigates failures, searches Jira, queries Confluence, creates branches, opens PRs, and files issues. All through natural language, all with graduated human oversight.
+
+### What's in v3.0.0
+
+**Agentic AI Copilot**
+- ReAct reasoning loop (Reason → Act → Observe → Answer) with real-time SSE streaming
+- 22 AI tools: 8 read-only (auto-execute), 11 write (tiered approval), 3 housekeeping
+- Virtual team of 9 specialist personas with two-tier routing (keyword → LLM fallback)
+- Graduated autonomy: Conservative / Balanced / Autonomous — user controls how much the AI does
+- Proactive suggestions after every tool result
+- In-chat provider picker: Anthropic, OpenAI, Google Gemini, Azure OpenAI, AWS Bedrock, OpenRouter
+
+**Test Intelligence**
+- Predictive failure analysis with trend aggregation, risk scoring, z-score anomaly detection
+- Flaky test detection via statistical scoring
+- Smart test selection based on code change impact analysis
+- Failure Knowledge Base with fingerprinting, historical trending, and category analytics
+
+**Security & Production Readiness**
+- SQL injection prevention (Prisma.sql tagged templates)
+- CSRF protection (double-submit cookie)
+- Redis session store with MemoryStore dev fallback
+- Structured logging (winston), request correlation (X-Request-ID)
+- Deep health checks (`/health/ready`, `/health/live`, `/health/full`)
+- `npm audit` clean at high severity (8 moderate in ESLint devDeps only)
+
+**CI & Quality Enforcement**
+- Commitlint + lint-staged enforce conventional commits on every commit
+- Architectural lint blocks layer violations
+- Code health check flags oversized files/functions
+- Schema parity CI gate with `--strict-fields`
+- Bug tracker workflow auto-labels fix PRs and links open issues
+- Living Feature Specs: 16 features, 229 assertions, 100% scanner pass
+
+**6 AI Providers**
+- Anthropic Claude (direct API)
+- OpenAI (GPT-4o, o1)
+- Google Gemini
+- Azure OpenAI
+- AWS Bedrock (Claude via IAM role or explicit credentials)
+- OpenRouter (multi-model gateway)
+
+### Known Limitations
+
+- **Demo mode login** requires no external services. Production mode requires Redis for CSRF session validation — this is by design (session security demands a persistent store). See [Production Quickstart](docs/PRODUCTION_QUICKSTART.md).
+- **Bedrock embedding** not yet supported — `embed()` throws with guidance to use Amazon Titan Embeddings directly. Chat and tool calling work fully.
+- **E2E tests** (Playwright) are available but not part of the default CI gate — run with `npm run test:e2e`.
+
+### Quality Gates
+
+| Gate | Status |
+|------|--------|
+| Tests | **760 passing** (38 backend suites + 13 frontend suites) |
+| TypeScript | Zero errors |
+| Build | All 3 packages compile |
+| Lint | Clean |
+| Architecture | No layer violations |
+| Health | All functions within limits |
+| Spec Scanner | 229/229 assertions (100%) |
+| Security Audit | 0 high/critical (8 moderate in devDeps) |
+
+### RC History
+
+| RC | Date | Focus |
+|----|------|-------|
+| rc.1 | 2026-02-21 | Specs complete, CI release workflow |
+| rc.2 | 2026-02-21 | Full beta coverage (16 features, 229 assertions) |
+| rc.3 | 2026-02-23 | Security hardening & production readiness audit |
+| rc.4 | 2026-02-26 | AWS Bedrock integration, CI quality gates |
+
+---
+
 ## [3.0.0-rc.4] - 2026-02-26
 
 > **AWS Bedrock Integration, CI Quality Gates & Bug Tracking**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/rayalon1984/testops-companion/actions/workflows/ci.yml/badge.svg)](https://github.com/rayalon1984/testops-companion/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](package.json)
-[![Version](https://img.shields.io/badge/version-3.0.0--rc.4-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-3.0.0-blue)](CHANGELOG.md)
 
 > **New here?** Start in 5 minutes: **[Quick Start Guide](docs/quickstart.md)** | [MCP Quick Start](docs/MCP_INTEGRATION.md) | [How Does It Work?](docs/HOW_DOES_IT_WORK.md)
 


### PR DESCRIPTION
## Summary

- Add v3.0.0 GA entry to CHANGELOG with complete feature summary across all 4 RCs
- Document known limitations: Redis for CSRF sessions, Bedrock embed not supported, E2E not in default CI
- Bump AGENTS.md version to 3.0.0
- Bump README version badge to 3.0.0
- All package.json files already at 3.0.0

## Verification Loop (AGENTS.md §5)

| Gate | Status |
|------|--------|
| Tests | 760 passing (623 backend + 137 frontend) |
| TypeScript | Zero errors |
| Lint | Clean |
| Architecture | No violations |
| Health | No violations |

## Test plan

- [x] `npm run test` — 760 passing
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — clean
- [x] `npm run check:architecture` — no violations
- [x] `npm run check:health` — no violations
- [x] Documentation only changes — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)