### PR TITLE
fix(ci): prevent release workflow from overwriting custom notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,21 @@ jobs:
           echo "${delimiter}"
         } >> $GITHUB_OUTPUT
 
+    - name: Check if release already exists
+      id: check_release
+      run: |
+        EXISTING=$(gh release view "v${{ steps.get_version.outputs.version }}" --json body --jq '.body' 2>/dev/null || echo "")
+        if [ -n "$EXISTING" ] && ! echo "$EXISTING" | grep -q "Changes in this release"; then
+          echo "skip=true" >> $GITHUB_OUTPUT
+          echo "Release already exists with custom notes — skipping overwrite"
+        else
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create Release
+      if: steps.check_release.outputs.skip != 'true'
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,7 +104,7 @@ jobs:
 
           ### 📖 Documentation
 
-          See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/v${{ steps.get_version.outputs.version }}/docs/project/CHANGELOG.md) for complete details.
+          See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/v${{ steps.get_version.outputs.version }}/CHANGELOG.md) for complete details.
         draft: false
         prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
 


### PR DESCRIPTION
## Summary

The release workflow (`release.yml`) was overwriting hand-crafted release notes every time a tag was pushed. This happened because the workflow unconditionally creates/updates the release with auto-generated content.

**Root cause:** `softprops/action-gh-release@v2` always overwrites the body. When tags are moved (e.g., to include late commits), the workflow re-triggers and replaces custom notes with commit message lists.

**Fix:** Added a pre-check step that detects if a release already has custom notes (not auto-generated). If custom notes exist, the create step is skipped.

Also fixed the CHANGELOG.md link in the template (was pointing to `docs/project/CHANGELOG.md`, should be `CHANGELOG.md`).

## Test plan

- [x] Workflow logic verified — `grep -q "Changes in this release"` only matches auto-generated content
- [x] Custom notes on v3.0.0 release confirmed intact after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)