### PR TITLE
fix(security): bump minimatch 10.2.4 + guard root lockfile

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'backend/**'
       - 'scripts/**'
+      - 'package-lock.json'
       - '.health-baseline.json'
       - '.github/workflows/backend-ci.yml'
   pull_request:
@@ -13,6 +14,7 @@ on:
     paths:
       - 'backend/**'
       - 'scripts/**'
+      - 'package-lock.json'
       - '.health-baseline.json'
       - '.github/workflows/backend-ci.yml'
 
@@ -78,6 +80,10 @@ jobs:
         npm run typecheck
 
     - name: Security audit (fail on high severity)
+      run: npm audit --audit-level=high
+
+    - name: Root lockfile audit (fail on high severity)
+      working-directory: .
       run: npm audit --audit-level=high
 
   docker-build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "testops-companion",
+  "name": "testops-copilot",
   "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "testops-companion",
+      "name": "testops-copilot",
       "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3787,9 +3787,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"


### PR DESCRIPTION
## Summary
- Bumps `minimatch` 10.2.2→10.2.4 in root `package-lock.json` to resolve two high-severity ReDoS CVEs (GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74)
- Adds `npm audit --audit-level=high` for the root lockfile in Backend CI, closing the gap where root devDependency vulnerabilities went undetected
- Adds `package-lock.json` to Backend CI path triggers so changes to it run the pipeline

Closes #494

## Test plan
- [x] `npm audit --audit-level=high` returns 0 vulnerabilities (root, backend, frontend)
- [x] All 764 unit tests pass (627 BE + 137 FE)
- [x] All 15 Playwright E2E tests pass
- [x] Typecheck, lint, build, architecture, health all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)