### PR TITLE
refactor: rename testops-companion → testops-copilot across codebase

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,17 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/yourusername/testops-companion/wiki
+    url: https://github.com/yourusername/testops-copilot/wiki
     about: Check our documentation before creating an issue
   - name: 💬 Discussions
-    url: https://github.com/yourusername/testops-companion/discussions
+    url: https://github.com/yourusername/testops-copilot/discussions
     about: Ask questions and discuss with other community members
   - name: 🤝 Contributing Guidelines
-    url: https://github.com/yourusername/testops-companion/blob/main/CONTRIBUTING.md
+    url: https://github.com/yourusername/testops-copilot/blob/main/CONTRIBUTING.md
     about: Review our contributing guidelines before submitting a PR
   - name: 📝 Code of Conduct
-    url: https://github.com/yourusername/testops-companion/blob/main/CODE_OF_CONDUCT.md
+    url: https://github.com/yourusername/testops-copilot/blob/main/CODE_OF_CONDUCT.md
     about: Please read our Code of Conduct
   - name: 🔒 Security Policy
-    url: https://github.com/yourusername/testops-companion/security/policy
+    url: https://github.com/yourusername/testops-copilot/security/policy
     about: Review our security policy for reporting vulnerabilities

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,9 +1,9 @@
 # Repository settings managed by probot-settings (https://probot.github.io/apps/settings/)
 
 repository:
-  name: testops-companion
+  name: testops-copilot
   description: A comprehensive test automation management platform
-  homepage: https://docs.testops-companion.com
+  homepage: https://docs.testops-copilot.com
   private: true
   has_issues: true
   has_projects: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
 
           ```bash
           git clone https://github.com/${{ github.repository }}.git
-          cd testops-companion
+          cd testops-copilot
           git checkout v${{ steps.get_version.outputs.version }}
           npm run setup
           ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,8 @@ This isn't a prototype. v3 went through a dedicated security audit in rc.3:
 ### Get Running in 2 Minutes
 
 ```bash
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion && npm install && npm run dev:simple
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot && npm install && npm run dev:simple
 ```
 
 No PostgreSQL. No Redis. No API keys. SQLite + mock AI provider. Login with `engineer@testops.ai` / `demo123` and start talking to the copilot.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rayalon1984/testops-companion/actions/workflows/ci.yml"><img src="https://github.com/rayalon1984/testops-companion/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rayalon1984/testops-copilot/actions/workflows/ci.yml"><img src="https://github.com/rayalon1984/testops-copilot/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-3.0.1-blue" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="package.json"><img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen" alt="Node.js Version"></a>
@@ -41,8 +41,8 @@ You review it, hit approve, and move on with your coffee.
 ## Get Running in 2 Minutes
 
 ```bash
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion && npm install && npm run dev:simple
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot && npm install && npm run dev:simple
 ```
 
 No PostgreSQL. No Redis. No API keys. Login with `engineer@testops.ai` / `demo123`.
@@ -253,7 +253,7 @@ Full API reference: **[docs/api.md](docs/api.md)**
 ## Project Structure
 
 ```
-testops-companion/
+testops-copilot/
 ├── backend/
 │   ├── prisma/                          # Schema (dev + production) & migrations
 │   └── src/
@@ -326,10 +326,10 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 </p>
 
 <p align="center">
-  <a href="https://github.com/rayalon1984/testops-companion/issues">Report a Bug</a> ·
-  <a href="https://github.com/rayalon1984/testops-companion/issues">Request a Feature</a>
+  <a href="https://github.com/rayalon1984/testops-copilot/issues">Report a Bug</a> ·
+  <a href="https://github.com/rayalon1984/testops-copilot/issues">Request a Feature</a>
 </p>
 
 <p align="center">
-  If you find this project useful, give it a <a href="https://github.com/rayalon1984/testops-companion">star</a>!
+  If you find this project useful, give it a <a href="https://github.com/rayalon1984/testops-copilot">star</a>!
 </p>

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,7 +56,7 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
-EMAIL_FROM=noreply@testops-companion.com
+EMAIL_FROM=noreply@testops-copilot.com
 
 # Monitoring
 SENTRY_DSN=

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -50,7 +50,7 @@ async function main() {
   };
 
   const githubConfig = {
-    repository: 'testops-companion',
+    repository: 'testops-copilot',
     workflow: 'test.yml',
     branch: 'main',
   };

--- a/backend/src/services/ai/__tests__/ProactiveSuggestionEngine.test.ts
+++ b/backend/src/services/ai/__tests__/ProactiveSuggestionEngine.test.ts
@@ -412,7 +412,7 @@ describe('ProactiveSuggestionEngine', () => {
           state: 'open',
           mergeable: true,
           number: 312,
-          repo: 'testops-companion',
+          repo: 'testops-copilot',
         }),
         previousResults: [],
         userMessage: 'Check PR #312',
@@ -424,7 +424,7 @@ describe('ProactiveSuggestionEngine', () => {
       expect(suggestion!.confidence).toBe(0.7);
       expect(suggestion!.actionLabel).toBe('Merge PR');
       expect(suggestion!.preparedArgs.prNumber).toBe(312);
-      expect(suggestion!.preparedArgs.repo).toBe('testops-companion');
+      expect(suggestion!.preparedArgs.repo).toBe('testops-copilot');
     });
 
     it('does NOT fire when PR is closed', () => {

--- a/backend/src/services/ai/__tests__/autonomy-flow.integration.test.ts
+++ b/backend/src/services/ai/__tests__/autonomy-flow.integration.test.ts
@@ -282,7 +282,7 @@ describe('Autonomy Flow Integration', () => {
         state: 'open',
         mergeable: true,
         number: 402,
-        repo: 'testops-companion',
+        repo: 'testops-copilot',
       });
 
       const suggestion = evaluateSuggestion({

--- a/backend/src/services/ai/__tests__/proactive-suggestions.feature.test.ts
+++ b/backend/src/services/ai/__tests__/proactive-suggestions.feature.test.ts
@@ -79,7 +79,7 @@ describeFeature('proactive-suggestions', () => {
   itAssertion('proactive.engine.mergeable-pr-suggest-merge', () => {
     const suggestion = evaluateSuggestion({
       toolName: 'github_get_pr',
-      toolResult: okResult({ state: 'open', mergeable: true, number: 312, repo: 'testops-companion' }),
+      toolResult: okResult({ state: 'open', mergeable: true, number: 312, repo: 'testops-copilot' }),
       previousResults: [],
       userMessage: 'Check PR #312',
     });

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -12,7 +12,7 @@
 
 services:
   frontend:
-    image: ghcr.io/rayalon1984/testops-companion/frontend:latest
+    image: ghcr.io/rayalon1984/testops-copilot/frontend:latest
     ports:
       - "80:80"
     restart: always
@@ -25,7 +25,7 @@ services:
       - testops-network
 
   backend:
-    image: ghcr.io/rayalon1984/testops-companion/backend:latest
+    image: ghcr.io/rayalon1984/testops-copilot/backend:latest
     ports:
       - "3000:3000"
     restart: always

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -93,7 +93,7 @@ Edit your Claude Code MCP configuration:
     "testops": {
       "command": "node",
       "args": [
-        "/absolute/path/to/testops-companion/mcp-server/dist/index.js"
+        "/absolute/path/to/testops-copilot/mcp-server/dist/index.js"
       ],
       "env": {
         "DATABASE_URL": "postgresql://testops:testops@localhost:5432/testops",
@@ -606,8 +606,8 @@ Quarterly: Audit knowledge base quality
 
 ### Getting Help
 
-- GitHub Issues: https://github.com/rayalon1984/testops-companion/issues
-- Discussions: https://github.com/rayalon1984/testops-companion/discussions
+- GitHub Issues: https://github.com/rayalon1984/testops-copilot/issues
+- Discussions: https://github.com/rayalon1984/testops-copilot/discussions
 
 ### Contributing
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -12,7 +12,7 @@ If you're running **v3.0.0 or earlier** and upgrading to v3.0.1, read below. If 
 
 ## 1. JWT Tokens (Re-login Required)
 
-**What changed**: JWT issuer/audience values changed from `testops-companion` / `testops-companion-client` to `testops-copilot` / `testops-copilot-client`.
+**What changed**: JWT issuer/audience values changed from `testops-copilot` / `testops-copilot-client` to `testops-copilot` / `testops-copilot-client`.
 
 **Impact**: All existing JWT tokens become invalid after upgrade.
 
@@ -24,7 +24,7 @@ If you're running **v3.0.0 or earlier** and upgrading to v3.0.1, read below. If 
 
 ## 2. Encrypted AI Provider Config (Automatic Fallback)
 
-**What changed**: The default encryption salt for AI provider API keys stored in the database changed from `testops-companion-default-enc-key` to `testops-copilot-default-enc-key`.
+**What changed**: The default encryption salt for AI provider API keys stored in the database changed from `testops-copilot-default-enc-key` to `testops-copilot-default-enc-key`.
 
 **Impact**: If you were using the **default encryption key** (no `AI_CONFIG_ENCRYPTION_KEY` env var set), your stored provider configs are encrypted with the old key.
 
@@ -37,10 +37,10 @@ If you're running **v3.0.0 or earlier** and upgrading to v3.0.1, read below. If 
 ## 3. Package Names
 
 **What changed**: npm package names changed:
-- `testops-companion` → `testops-copilot`
-- `testops-companion-backend` → `testops-copilot-backend`
-- `testops-companion-frontend` → `testops-copilot-frontend`
-- `@testops-companion/mcp-server` → `@testops-copilot/mcp-server`
+- `testops-copilot` → `testops-copilot`
+- `testops-copilot-backend` → `testops-copilot-backend`
+- `testops-copilot-frontend` → `testops-copilot-frontend`
+- `@testops-copilot/mcp-server` → `@testops-copilot/mcp-server`
 
 **Impact**: If you reference these packages by name in scripts, Docker builds, or CI configs, update the references.
 
@@ -62,7 +62,7 @@ If you're running **v3.0.0 or earlier** and upgrading to v3.0.1, read below. If 
 
 ## 5. OpenTelemetry Service Name
 
-**What changed**: Default OTEL service name changed from `testops-companion-backend` to `testops-copilot-backend`.
+**What changed**: Default OTEL service name changed from `testops-copilot-backend` to `testops-copilot-backend`.
 
 **Impact**: If you query traces/metrics by service name, update your Grafana/Prometheus dashboards.
 

--- a/docs/PRODUCTION_QUICKSTART.md
+++ b/docs/PRODUCTION_QUICKSTART.md
@@ -13,8 +13,8 @@ Deploy TestOps Copilot to production in under 5 minutes.
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 
 # 2. Copy production env template
 cp .env.production.example .env.production
@@ -61,7 +61,7 @@ curl -X POST http://localhost:3000/api/v1/auth/register \
 ## 🔄 Updating to New Version
 
 ```bash
-cd testops-companion
+cd testops-copilot
 docker compose -f docker-compose.ghcr.yml pull
 docker compose -f docker-compose.ghcr.yml up -d
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,4 +92,4 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](../LIC
 
 ## Support
 
-- [GitHub Issues](https://github.com/rayalon1984/testops-companion/issues) - Report bugs or request features
+- [GitHub Issues](https://github.com/rayalon1984/testops-copilot/issues) - Report bugs or request features

--- a/docs/archive/BETA.md
+++ b/docs/archive/BETA.md
@@ -164,9 +164,9 @@ TestOps Copilot is **open source** and **free**. Premium features (if we add the
 
 Have questions before applying?
 
-- 📧 **Email**: rotem@testops-companion.dev (or your email)
+- 📧 **Email**: rotem@testops-copilot.dev (or your email)
 - 💬 **LinkedIn**: [Rotem Ayalon](https://www.linkedin.com/in/YOUR_PROFILE)
-- 🐙 **GitHub Issues**: [Ask anything](https://github.com/rayalon1984/testops-companion/issues)
+- 🐙 **GitHub Issues**: [Ask anything](https://github.com/rayalon1984/testops-copilot/issues)
 
 ## 🚀 Ready to Join?
 

--- a/docs/archive/CREATE_PR.md
+++ b/docs/archive/CREATE_PR.md
@@ -4,7 +4,7 @@
 
 Visit this URL in your browser:
 ```
-https://github.com/rayalon1984/testops-companion/pull/new/claude/optimize-mcp-testops-jpKj5
+https://github.com/rayalon1984/testops-copilot/pull/new/claude/optimize-mcp-testops-jpKj5
 ```
 
 ## PR Details
@@ -34,7 +34,7 @@ failures with 98% token reduction and 90% cost savings.
 
 ### Full Description (paste PR_DESCRIPTION.md content)
 
-See the complete PR description in: `/home/user/testops-companion/PR_DESCRIPTION.md`
+See the complete PR description in: `/home/user/testops-copilot/PR_DESCRIPTION.md`
 
 Copy the entire contents of that file into the PR description field on GitHub.
 

--- a/docs/archive/DEPLOYMENT_COMPLETE.md
+++ b/docs/archive/DEPLOYMENT_COMPLETE.md
@@ -328,7 +328,7 @@ Large Team (2000 runs):  $173/year (vs $240 conservative)
 
 1. **Visit PR URL:**
    ```
-   https://github.com/rayalon1984/testops-companion/pull/new/claude/optimize-mcp-testops-jpKj5
+   https://github.com/rayalon1984/testops-copilot/pull/new/claude/optimize-mcp-testops-jpKj5
    ```
 
 2. **Use This Title:**
@@ -338,7 +338,7 @@ Large Team (2000 runs):  $173/year (vs $240 conservative)
 
 3. **Paste Description From:**
    ```
-   /home/user/testops-companion/PR_DESCRIPTION.md
+   /home/user/testops-copilot/PR_DESCRIPTION.md
    ```
 
 4. **Add Labels:**
@@ -436,8 +436,8 @@ Restart Claude Code and ask:
 - **Changelog:** `CHANGELOG.md`
 
 ### Get Help
-- **Issues:** https://github.com/rayalon1984/testops-companion/issues
-- **Discussions:** https://github.com/rayalon1984/testops-companion/discussions
+- **Issues:** https://github.com/rayalon1984/testops-copilot/issues
+- **Discussions:** https://github.com/rayalon1984/testops-copilot/discussions
 
 ---
 

--- a/docs/archive/INSTALLATION_FIXES_SUMMARY.md
+++ b/docs/archive/INSTALLATION_FIXES_SUMMARY.md
@@ -119,8 +119,8 @@ npm run dev
 
 ```bash
 # Just run the new setup script
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 bash scripts/setup-validated.sh
 ```
 
@@ -181,7 +181,7 @@ If you encounter any issues with the updated installation:
 
 1. Check `QUICKSTART.md` for step-by-step instructions
 2. Review `INSTALLATION_ISSUES_REPORT.md` for technical details
-3. Open an issue: https://github.com/rayalon1984/testops-companion/issues
+3. Open an issue: https://github.com/rayalon1984/testops-copilot/issues
 4. Include:
    - Operating system
    - Node.js version (`node --version`)

--- a/docs/archive/INSTALLATION_ISSUES_REPORT.md
+++ b/docs/archive/INSTALLATION_ISSUES_REPORT.md
@@ -336,8 +336,8 @@ Error: Database 'testops' does not exist
 
 1. **Use new setup script**:
    ```bash
-   git clone https://github.com/rayalon1984/testops-companion.git
-   cd testops-companion
+   git clone https://github.com/rayalon1984/testops-copilot.git
+   cd testops-copilot
    bash scripts/setup-validated.sh
    ```
 

--- a/docs/archive/MCP_SERVER_SUMMARY.md
+++ b/docs/archive/MCP_SERVER_SUMMARY.md
@@ -217,7 +217,7 @@ Configuration file: `~/.claude/config.json`
   "mcpServers": {
     "testops": {
       "command": "node",
-      "args": ["/path/to/testops-companion/mcp-server/dist/index.js"],
+      "args": ["/path/to/testops-copilot/mcp-server/dist/index.js"],
       "env": {
         "DATABASE_URL": "postgresql://testops:testops@localhost:5432/testops"
       }

--- a/docs/archive/RELEASE_NOTES_v2.5.6.md
+++ b/docs/archive/RELEASE_NOTES_v2.5.6.md
@@ -122,8 +122,8 @@ Three new documentation files:
 ### For Fresh Installations:
 
 ```bash
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 bash scripts/setup-validated.sh
 npm run dev
 ```
@@ -131,7 +131,7 @@ npm run dev
 ### For Existing Broken Installations:
 
 ```bash
-cd testops-companion
+cd testops-copilot
 git pull origin main
 npm run setup:clean
 rm -f backend/.env frontend/.env
@@ -209,7 +209,7 @@ If you encounter any issues:
 
 1. Review [QUICKSTART.md](quickstart.md) for installation steps
 2. Check [INSTALLATION_ISSUES_REPORT.md](INSTALLATION_ISSUES_REPORT.md) for troubleshooting
-3. Open an issue: https://github.com/rayalon1984/testops-companion/issues
+3. Open an issue: https://github.com/rayalon1984/testops-copilot/issues
 
 Include:
 - Operating system and version
@@ -236,9 +236,9 @@ Include:
 
 ---
 
-**Full Changelog**: https://github.com/rayalon1984/testops-companion/compare/v2.5.5...v2.5.6
+**Full Changelog**: https://github.com/rayalon1984/testops-copilot/compare/v2.5.5...v2.5.6
 
-**Download**: https://github.com/rayalon1984/testops-companion/archive/refs/tags/v2.5.6.zip
+**Download**: https://github.com/rayalon1984/testops-copilot/archive/refs/tags/v2.5.6.zip
 
 ---
 

--- a/docs/archive/RELEASE_NOTES_v2.6.0.md
+++ b/docs/archive/RELEASE_NOTES_v2.6.0.md
@@ -95,7 +95,7 @@ Edit `~/.claude/config.json`:
   "mcpServers": {
     "testops": {
       "command": "node",
-      "args": ["/path/to/testops-companion/mcp-server/dist/index.js"],
+      "args": ["/path/to/testops-copilot/mcp-server/dist/index.js"],
       "env": {
         "DATABASE_URL": "postgresql://testops:testops@localhost:5432/testops"
       }
@@ -217,8 +217,8 @@ Thank you to the community for your continued support! This release represents m
 ## 📞 Support
 
 - **Documentation:** [docs/MCP_INTEGRATION.md](MCP_INTEGRATION.md)
-- **Issues:** https://github.com/rayalon1984/testops-companion/issues
-- **Discussions:** https://github.com/rayalon1984/testops-companion/discussions
+- **Issues:** https://github.com/rayalon1984/testops-copilot/issues
+- **Discussions:** https://github.com/rayalon1984/testops-copilot/discussions
 
 ## 📈 Stats
 
@@ -230,9 +230,9 @@ Thank you to the community for your continued support! This release represents m
 
 ---
 
-**Download:** [v2.6.0](https://github.com/rayalon1984/testops-companion/releases/tag/v2.6.0)
+**Download:** [v2.6.0](https://github.com/rayalon1984/testops-copilot/releases/tag/v2.6.0)
 
-**Previous Release:** [v2.5.6](https://github.com/rayalon1984/testops-companion/releases/tag/v2.5.6)
+**Previous Release:** [v2.5.6](https://github.com/rayalon1984/testops-copilot/releases/tag/v2.5.6)
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,8 +31,8 @@ This guide covers different deployment options for TestOps Copilot, from develop
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/testops-companion.git
-cd testops-companion
+git clone https://github.com/yourusername/testops-copilot.git
+cd testops-copilot
 ```
 
 2. Install dependencies:
@@ -148,7 +148,7 @@ npm run build
 
 2. Configure Nginx:
 ```nginx
-# /etc/nginx/sites-available/testops-companion
+# /etc/nginx/sites-available/testops-copilot
 server {
     listen 80;
     server_name your-domain.com;
@@ -172,7 +172,7 @@ server {
 
     # Frontend
     location / {
-        root /var/www/testops-companion;
+        root /var/www/testops-copilot;
         try_files $uri $uri/ /index.html;
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate";
@@ -192,7 +192,7 @@ server {
 
 3. Deploy frontend files:
 ```bash
-sudo cp -r dist/* /var/www/testops-companion/
+sudo cp -r dist/* /var/www/testops-copilot/
 ```
 
 ## CI/CD Setup
@@ -329,7 +329,7 @@ curl -X POST "https://api.uptimerobot.com/v2/newMonitor" \
 2. Application backups:
 ```bash
 # Add to crontab
-0 0 * * * tar -czf /backups/testops_$(date +\%Y\%m\%d).tar.gz /var/www/testops-companion
+0 0 * * * tar -czf /backups/testops_$(date +\%Y\%m\%d).tar.gz /var/www/testops-copilot
 ```
 
 ## SSL Certificate Setup

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ For installation and setup instructions, see the **[Quick Start Guide](quickstar
 ## Project Structure
 
 ```
-testops-companion/
+testops-copilot/
 ├── backend/                 # Backend application
 │   ├── src/
 │   │   ├── config/         # Configuration files

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,8 +23,8 @@ Yes, TestOps Copilot is open source and free to use. We also offer enterprise fe
 #### How do I install TestOps Copilot?
 ```bash
 # Clone the repository
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 
 # Quick demo (no Docker needed)
 npm install && npm run dev:simple
@@ -178,7 +178,7 @@ npm run test:coverage
 ### Enterprise Features
 
 #### How do I enable enterprise features?
-Contact our sales team at sales@testops-companion.com for enterprise licensing.
+Contact our sales team at sales@testops-copilot.com for enterprise licensing.
 
 #### What's included in enterprise features?
 - SAML/SSO integration
@@ -209,8 +209,8 @@ Contact our sales team at sales@testops-companion.com for enterprise licensing.
 #### Where can I get help?
 - [Quick Start Guide](quickstart.md)
 - [Troubleshooting Guide](troubleshooting.md)
-- [GitHub Issues](https://github.com/rayalon1984/testops-companion/issues)
-- [GitHub Discussions](https://github.com/rayalon1984/testops-companion/discussions)
+- [GitHub Issues](https://github.com/rayalon1984/testops-copilot/issues)
+- [GitHub Discussions](https://github.com/rayalon1984/testops-copilot/discussions)
 
 #### How do I report a bug?
 1. Check existing issues

--- a/docs/features/FAILURE_KNOWLEDGE_BASE.md
+++ b/docs/features/FAILURE_KNOWLEDGE_BASE.md
@@ -445,7 +445,7 @@ Future enhancements:
 ## Support
 
 For questions or issues:
-- GitHub Issues: [testops-companion/issues](https://github.com/rayalon1984/testops-companion/issues)
+- GitHub Issues: [testops-copilot/issues](https://github.com/rayalon1984/testops-copilot/issues)
 - Documentation: [docs/](../README.md)
 
 ---

--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -125,7 +125,7 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'testops-companion'
+  - job_name: 'testops-copilot'
     static_configs:
       - targets: ['localhost:3000']
     metrics_path: '/metrics'
@@ -198,7 +198,7 @@ global:
 
 # Scrape TestOps Copilot metrics
 scrape_configs:
-  - job_name: 'testops-companion'
+  - job_name: 'testops-copilot'
     static_configs:
       - targets: ['localhost:3000']
         labels:
@@ -219,7 +219,7 @@ scrape_configs:
 
 1. Open Prometheus UI: `http://localhost:9090`
 2. Go to **Status** → **Targets**
-3. Verify `testops-companion` target is **UP**
+3. Verify `testops-copilot` target is **UP**
 4. Query a metric: `testops_test_runs_total`
 
 ---
@@ -543,7 +543,7 @@ curl http://localhost:3000/metrics
 
 For issues or questions:
 - Check [Troubleshooting](#troubleshooting) section
-- Open an issue on [GitHub](https://github.com/rayalon1984/testops-companion/issues)
+- Open an issue on [GitHub](https://github.com/rayalon1984/testops-copilot/issues)
 - Review Prometheus/Grafana documentation
 
 ---

--- a/docs/integrations/jira.md
+++ b/docs/integrations/jira.md
@@ -200,5 +200,5 @@ JIRA_DEBUG=true
 For issues with the Jira integration:
 
 1. Check the [troubleshooting guide](#troubleshooting)
-2. Review [GitHub issues](https://github.com/rayalon1984/testops-companion/issues)
-3. Join our [Discord community](https://discord.gg/testops-companion)
+2. Review [GitHub issues](https://github.com/rayalon1984/testops-copilot/issues)
+3. Join our [Discord community](https://discord.gg/testops-copilot)

--- a/docs/integrations/monday.md
+++ b/docs/integrations/monday.md
@@ -591,7 +591,7 @@ Monday.com has API rate limits:
 
 For issues or questions:
 - Check the [FAQ](../faq.md)
-- Open an issue on [GitHub](https://github.com/rayalon1984/testops-companion/issues)
+- Open an issue on [GitHub](https://github.com/rayalon1984/testops-copilot/issues)
 - Review Monday.com API documentation
 
 ---

--- a/docs/integrations/testrail.md
+++ b/docs/integrations/testrail.md
@@ -515,8 +515,8 @@ TestRail API has the following limits:
 ## Need Help?
 
 - 📖 [TestOps Copilot Documentation](../README.md)
-- 🐛 [Report an Issue](https://github.com/rayalon1984/testops-companion/issues)
-- 💬 [Discussions](https://github.com/rayalon1984/testops-companion/discussions)
+- 🐛 [Report an Issue](https://github.com/rayalon1984/testops-copilot/issues)
+- 💬 [Discussions](https://github.com/rayalon1984/testops-copilot/discussions)
 
 ---
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -5,7 +5,7 @@
 TestOps Copilot follows a monorepo structure with separate frontend and backend applications.
 
 ```
-testops-companion/
+testops-copilot/
 ├── backend/                 # Backend application
 │   ├── src/                # Source code
 │   │   ├── config/         # Configuration files

--- a/docs/project/CODE_OF_CONDUCT.md
+++ b/docs/project/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-conduct@testops-companion.com. All complaints will be reviewed and investigated 
+conduct@testops-copilot.com. All complaints will be reviewed and investigated 
 promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/docs/project/CONTRIBUTING.md
+++ b/docs/project/CONTRIBUTING.md
@@ -55,10 +55,10 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 ```bash
 # Clone your fork
-git clone https://github.com/<your-username>/testops-companion.git
+git clone https://github.com/<your-username>/testops-copilot.git
 
 # Navigate to the project directory
-cd testops-companion
+cd testops-copilot
 
 # Install global dependencies
 npm install -g typescript ts-node
@@ -80,7 +80,7 @@ The setup script will:
 ### Project Structure
 
 ```
-testops-companion/
+testops-copilot/
 ├── .github/          # GitHub Actions workflows and templates
 ├── backend/          # Backend Node.js/Express application
 ├── frontend/         # Frontend React application

--- a/docs/project/RELEASE_PROCESS.md
+++ b/docs/project/RELEASE_PROCESS.md
@@ -94,7 +94,7 @@ TestOps Copilot follows [Semantic Versioning](https://semver.org/):
 ### 3. Post-Release Tasks
 
 - [ ] **Verify Release Artifacts**
-  - Check Docker images are available: `docker pull ghcr.io/rayalon1984/testops-companion/backend:1.1.0`
+  - Check Docker images are available: `docker pull ghcr.io/rayalon1984/testops-copilot/backend:1.1.0`
   - Verify release page displays correctly
   - Test documentation links
 
@@ -167,8 +167,8 @@ Brief summary of the most important changes in this release.
 
 ```bash
 # Clone the repository
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 
 # Checkout this version
 git checkout v1.1.0
@@ -180,8 +180,8 @@ npm run setup
 ### 🐳 Docker Images
 
 ```bash
-docker pull ghcr.io/rayalon1984/testops-companion/backend:1.1.0
-docker pull ghcr.io/rayalon1984/testops-companion/frontend:1.1.0
+docker pull ghcr.io/rayalon1984/testops-copilot/backend:1.1.0
+docker pull ghcr.io/rayalon1984/testops-copilot/frontend:1.1.0
 ```
 
 ### 📖 Full Changelog
@@ -194,7 +194,7 @@ Thanks to everyone who contributed to this release!
 
 ---
 
-**Previous Release:** [v1.0.0](https://github.com/rayalon1984/testops-companion/releases/tag/v1.0.0)
+**Previous Release:** [v1.0.0](https://github.com/rayalon1984/testops-copilot/releases/tag/v1.0.0)
 **Next Release:** [v1.2.0 Roadmap](ROADMAP.md)
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,8 +12,8 @@ Get started with TestOps Copilot in minutes. Choose the path that fits your need
 
 ```bash
 # Clone and start
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 npm install
 npm run dev:simple
 ```
@@ -42,8 +42,8 @@ npm run dev:simple
 **Prerequisites**: Node.js 18+, npm 9+, Docker Desktop
 
 ```bash
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 npm install
 
 # Start infrastructure (PostgreSQL, Redis, Weaviate)
@@ -265,4 +265,4 @@ npm run build            # Build for production
 - [API Reference](api.md) — Full REST API documentation
 - [Architecture](architecture.md) — System design overview
 - [Lessons Learned](LESSONS_LEARNED.md) — Known pitfalls and prevention
-- [GitHub Issues](https://github.com/rayalon1984/testops-companion/issues) — Report bugs or request features
+- [GitHub Issues](https://github.com/rayalon1984/testops-copilot/issues) — Report bugs or request features

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,5 +194,5 @@ docker compose exec redis redis-cli FLUSHALL
 
 1. Check the [Quick Start Guide](quickstart.md) for setup instructions
 2. Review [Lessons Learned](LESSONS_LEARNED.md) for known pitfalls
-3. Search [existing issues](https://github.com/rayalon1984/testops-companion/issues)
-4. Open a [new issue](https://github.com/rayalon1984/testops-companion/issues/new/choose)
+3. Search [existing issues](https://github.com/rayalon1984/testops-copilot/issues)
+4. Open a [new issue](https://github.com/rayalon1984/testops-copilot/issues/new/choose)

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -14,7 +14,7 @@ WEAVIATE_API_KEY=
 REDIS_URL=redis://localhost:6379
 
 # MCP Server Configuration
-MCP_SERVER_NAME=testops-companion
+MCP_SERVER_NAME=testops-copilot
 MCP_SERVER_VERSION=1.0.0
 LOG_LEVEL=info
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -53,4 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[1.0.0]: https://github.com/rayalon1984/testops-companion/releases/tag/mcp-v1.0.0
+[1.0.0]: https://github.com/rayalon1984/testops-copilot/releases/tag/mcp-v1.0.0

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -32,7 +32,7 @@ Add to your Claude Code MCP settings (`~/.claude/config.json`):
   "mcpServers": {
     "testops": {
       "command": "node",
-      "args": ["/path/to/testops-companion/mcp-server/dist/index.js"],
+      "args": ["/path/to/testops-copilot/mcp-server/dist/index.js"],
       "env": {
         "DATABASE_URL": "postgresql://user:pass@localhost:5432/testops"
       }
@@ -357,4 +357,4 @@ Contributions welcome! See main project [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 
-**Need help?** Open an issue at https://github.com/rayalon1984/testops-companion/issues
+**Need help?** Open an issue at https://github.com/rayalon1984/testops-copilot/issues

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -55,7 +55,7 @@ import {
 } from './tools/stats.js';
 
 // Server configuration
-const SERVER_NAME = process.env.MCP_SERVER_NAME || 'testops-companion';
+const SERVER_NAME = process.env.MCP_SERVER_NAME || 'testops-copilot';
 const SERVER_VERSION = process.env.MCP_SERVER_VERSION || '1.0.0';
 
 // Create MCP server

--- a/plan.md
+++ b/plan.md
@@ -81,7 +81,7 @@ These plans are completed and no longer actionable:
 - User Guides section: `docs/guides/pipelines.md`, `docs/guides/test-execution.md`, `docs/guides/notifications.md`, `docs/guides/dashboard.md`, `docs/guides/reports.md` — none exist
 - Reference section: `docs/reference/configuration.md`, `docs/reference/environment-variables.md`, `docs/reference/cli-commands.md`, `docs/reference/error-codes.md` — none exist
 - `docs/authentication.md` — doesn't exist
-- Remove fake external links: `docs.testops-companion.com`, `discord.gg/testops-companion`, `newsletter.testops-companion.com`, `twitter.com/testops-companion`
+- Remove fake external links: `docs.testops-copilot.com`, `discord.gg/testops-copilot`, `newsletter.testops-copilot.com`, `twitter.com/testops-copilot`
 
 ### 4b. `docs/project/RELEASE_PROCESS.md`
 - Says "Latest Release: v2.5.0 (2025-11-16)" — update to v3.0.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -72,8 +72,8 @@ backup_database() {
 check_ssl_certificates() {
     echo -e "${YELLOW}Checking SSL certificates...${NC}"
     
-    local cert_path="./nginx/ssl/testops-companion.crt"
-    local key_path="./nginx/ssl/testops-companion.key"
+    local cert_path="./nginx/ssl/testops-copilot.crt"
+    local key_path="./nginx/ssl/testops-copilot.key"
     
     if [ ! -f "$cert_path" ] || [ ! -f "$key_path" ]; then
         echo -e "${RED}Error: SSL certificates not found${NC}"

--- a/scripts/push-all-releases.sh
+++ b/scripts/push-all-releases.sh
@@ -20,7 +20,7 @@ if [ ! -t 0 ]; then
   exit $_rc
 fi
 
-REPO="rayalon1984/testops-companion"
+REPO="rayalon1984/testops-copilot"
 
 echo "==> Pushing all tags to origin..."
 git push origin --tags
@@ -313,8 +313,8 @@ Circuit breakers, automatic retries, and timeout management on every external se
 ## Get Started
 
 ```bash
-git clone https://github.com/rayalon1984/testops-companion.git
-cd testops-companion
+git clone https://github.com/rayalon1984/testops-copilot.git
+cd testops-copilot
 git checkout v3.0.0-beta.1
 npm run setup
 ```
@@ -322,7 +322,7 @@ npm run setup
 ---
 
 > **This is a beta release.** We're actively collecting feedback before GA.
-> Found an issue? [Open a bug report →](https://github.com/rayalon1984/testops-companion/issues)
+> Found an issue? [Open a bug report →](https://github.com/rayalon1984/testops-copilot/issues)
 NOTES
 upsert_release "v3.0.0-beta.1" \
   "TestOps Copilot v3.0.0-beta.1 — AI That Thinks, Acts, and Learns" \
@@ -343,7 +343,7 @@ The full agentic copilot flow is now covered by Playwright smoke tests.
 - **CI-ready** with auto-start, retries, and trace capture on failure
 - **Scenarios covered:** ReAct loop, confirmation flow, proactive suggestions, autonomous actions, persona routing, session persistence
 
-> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-companion/issues)
+> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-copilot/issues)
 NOTES
 upsert_release "v3.0.1-beta.1" \
   "TestOps Copilot v3.0.1-beta.1 — End-to-End Test Coverage" \
@@ -363,7 +363,7 @@ New users get a guided onboarding flow. Existing users get smarter error handlin
 - **Budget Indicator** — live spend badge with 80% warning threshold
 - **Smart Error Recovery** — auto-retry for network errors, budget links for rate limits, visual error classification
 
-> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-companion/issues)
+> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-copilot/issues)
 NOTES
 upsert_release "v3.0.2-beta.1" \
   "TestOps Copilot v3.0.2-beta.1 — First-Run Experience & Error Recovery" \
@@ -390,7 +390,7 @@ Specs are no longer passive documentation. This release connects product specifi
 - 323 tests passing, build/typecheck/lint all clean
 - Spec scanner: 3 features, 43 assertions valid
 
-> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-companion/issues)
+> This is a pre-release build. [Report issues →](https://github.com/rayalon1984/testops-copilot/issues)
 NOTES
 upsert_release "v3.0.3-beta.1" \
   "TestOps Copilot v3.0.3-beta.1 — Living Feature Specs" \

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -83,4 +83,4 @@ echo "2. Run 'npm run dev' in the frontend directory to start the development se
 echo "3. Run 'npm run dev' in the backend directory to start the API server"
 echo "4. Visit http://localhost:5173 to view the application"
 echo -e "\n${YELLOW}For more information, see the documentation at:${NC}"
-echo "https://github.com/rayalon1984/testops-companion/blob/main/docs/development.md"
+echo "https://github.com/rayalon1984/testops-copilot/blob/main/docs/development.md"


### PR DESCRIPTION
## Summary
- Renames all 121 occurrences of `testops-companion` → `testops-copilot` across 45 files to complete the v3.0.1 product rebrand
- Covers runtime code, CI/CD, Docker, scripts, docs, tests, and GitHub config
- Preserves `LEGACY_ENCRYPTION_SECRET = 'testops-companion-default-enc-key'` for backward-compatible decryption of pre-rebrand encrypted data

Closes #495

## Test plan
- [x] 627 backend unit tests pass
- [x] 137 frontend unit tests pass
- [x] 15 Playwright E2E tests pass
- [x] Typecheck, lint, build, architecture, health all clean
- [x] Security audit: 0 high-severity vulnerabilities
- [x] Only remaining `testops-companion` reference is the intentional `LEGACY_ENCRYPTION_SECRET`

## After merge — repo rename steps
See issue #495 for the manual repo rename instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)